### PR TITLE
Fix level generator obstacle cleanup typo

### DIFF
--- a/scripts/LevelGenerator.gd
+++ b/scripts/LevelGenerator.gd
@@ -251,10 +251,10 @@ func clear_existing_objects():
 	if exit_spawner and is_instance_valid(exit_spawner):
 		exit_spawner.clear_exit()
 
-	for obstacle in obstacles:
-		if is_instance_valid(obstacle):
-			obstacle.queue_free()
-	opstacles.clear()
+        for obstacle in obstacles:
+                if is_instance_valid(obstacle):
+                        obstacle.queue_free()
+        obstacles.clear()
 	for coin in coins:
 		if is_instance_valid(coin):
 			coin.queue_free()


### PR DESCRIPTION
## Summary
- correct the typo in `LevelGenerator.clear_existing_objects()` that prevented the obstacle array from being cleared
- ensure the level generator script loads so gameplay objects spawn and timers progress normally

## Testing
- not run (Godot engine not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dac5b2861083239d13ff901746e08e