### PR TITLE
Refactor level and coin generation modules

### DIFF
--- a/scripts/CoinSpawner.gd
+++ b/scripts/CoinSpawner.gd
@@ -1,6 +1,10 @@
 extends Node2D
 
 const Logger = preload("res://scripts/Logger.gd")
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+const LevelNodeFactory = preload("res://scripts/level_generators/LevelNodeFactory.gd")
+const CoinNavigation = preload("res://scripts/coin/CoinNavigation.gd")
+const CoinPlacementValidator = preload("res://scripts/coin/CoinPlacementValidator.gd")
 
 const NAV_CELL_SIZE := 16.0
 const PLAYER_DIAMETER := 32.0
@@ -14,9 +18,8 @@ func generate_coins(level_size: float, obstacles: Array, exit_pos: Vector2, play
 	current_level_size = level_size
 	clear_coins()
 
-	# 1) Счёт монет с мягкой прогрессией
 	var base_coin_count: int = randi_range(10, 25)
-	var level_multiplier: float = 1.0 + (level - 1) * 0.12 # было 0.15
+	var level_multiplier: float = 1.0 + (level - 1) * 0.12
 	var coin_count: int = int(base_coin_count * current_level_size * level_multiplier)
 
 	if level == 1:
@@ -24,26 +27,17 @@ func generate_coins(level_size: float, obstacles: Array, exit_pos: Vector2, play
 	else:
 		coin_count = max(preserved_coin_count + randi_range(1, 3), coin_count)
 
-	# Ограничим разумными рамками
 	coin_count = clamp(coin_count, 6, 40)
 
 	Logger.log_generation("CoinSpawner target count %d (mult %.2f, preserved %d)" % [coin_count, level_multiplier, preserved_coin_count])
 	if not use_full_map_coverage:
 		Logger.log_generation("CoinSpawner using centered coverage grid")
 
-	var navigation_ctx := _build_navigation_context(obstacles)
+	var navigation_ctx := CoinNavigation.build_navigation_context(current_level_size, obstacles, NAV_CELL_SIZE, PLAYER_DIAMETER, PATH_WIDTH_SCALE)
 
-	# 2) Параметры генерации
-	var grid_cols: int
-	var grid_rows: int
-	if use_full_map_coverage:
-		grid_cols = 8
-		grid_rows = 6
-	else:
-		grid_cols = 6
-		grid_rows = 5
+	var grid_cols: int = use_full_map_coverage ? 8 : 6
+	var grid_rows: int = use_full_map_coverage ? 6 : 5
 
-	# 3) Попытки: больше и с поэтапным послаблением
 	var max_attempts_total: int = coin_count * 60
 	var attempts_total: int = 0
 
@@ -51,17 +45,12 @@ func generate_coins(level_size: float, obstacles: Array, exit_pos: Vector2, play
 		var placed := false
 		var coin_attempts := 0
 
-		while not placed and coin_attempts < 80: # было 20
-			# коэффициент «расслабления» ограничений от 0.0 до 1.0
+		while not placed and coin_attempts < 80:
 			var relax: float = clamp(float(coin_attempts) / 60.0, 0.0, 1.0)
 
-			var coin := create_coin(grid_cols, grid_rows)
-			if is_valid_coin_position_relaxed(coin.position, obstacles, exit_pos, relax) and _has_clear_path(navigation_ctx, player_start, coin.position):
-				coins.append(coin)
-				if main_scene:
-					main_scene.call_deferred("add_child", coin)
-				else:
-					get_tree().current_scene.call_deferred("add_child", coin)
+			var coin := _create_coin(grid_cols, grid_rows)
+			if CoinPlacementValidator.is_valid_position(coin.position, coins, obstacles, exit_pos, relax) and CoinNavigation.has_clear_path(navigation_ctx, player_start, coin.position):
+				_add_coin(coin, main_scene)
 				placed = true
 			else:
 				coin.queue_free()
@@ -70,17 +59,12 @@ func generate_coins(level_size: float, obstacles: Array, exit_pos: Vector2, play
 				if attempts_total >= max_attempts_total:
 					break
 
-			if not placed:
-				# Последний шанс: ослабляем максимально, но всё ещё избегаем жёстких пересечений
-				var coin_fallback := create_coin(grid_cols, grid_rows)
-				if is_valid_coin_position_relaxed(coin_fallback.position, obstacles, exit_pos, 1.0) and _has_clear_path(navigation_ctx, player_start, coin_fallback.position):
-					coins.append(coin_fallback)
-					if main_scene:
-						main_scene.call_deferred("add_child", coin_fallback)
-					else:
-						get_tree().current_scene.call_deferred("add_child", coin_fallback)
-				else:
-					coin_fallback.queue_free()
+		if not placed:
+			var coin_fallback := _create_coin(grid_cols, grid_rows)
+			if CoinPlacementValidator.is_valid_position(coin_fallback.position, coins, obstacles, exit_pos, 1.0) and CoinNavigation.has_clear_path(navigation_ctx, player_start, coin_fallback.position):
+				_add_coin(coin_fallback, main_scene)
+			else:
+				coin_fallback.queue_free()
 
 		if attempts_total >= max_attempts_total:
 			break
@@ -88,199 +72,21 @@ func generate_coins(level_size: float, obstacles: Array, exit_pos: Vector2, play
 	Logger.log_generation("CoinSpawner placed %d coins" % coins.size())
 	return coins
 
-func create_coin(grid_cols: int, grid_rows: int) -> Area2D:
-	var coin := Area2D.new()
-	coin.name = "Coin" + str(coins.size())
-
-	var pos := LevelUtils.get_grid_position(current_level_size, grid_cols, grid_rows, 40, 30)
-	coin.position = pos
-
-	var body := ColorRect.new()
-	body.name = "CoinBody"
-	body.offset_right = 20
-	body.offset_bottom = 20
-	body.color = Color(1, 1, 0, 1)
-	coin.add_child(body)
-
-	var collision := CollisionShape2D.new()
-	collision.name = "CoinCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(20, 20)
-	collision.shape = shape
-	collision.position = Vector2(10, 10)
-	coin.add_child(collision)
-
-	return coin
-
-# --- Новая валидация с поэтапным «расслаблением» ---
-# relax = 0.0 (строго) … 1.0 (мягко)
-func is_valid_coin_position_relaxed(p: Vector2, obstacles: Array, exit_pos: Vector2, relax: float) -> bool:
-	# Базовые радиусы
-	var player_margin_strict: float = 24.0 # строгий запас
-	var player_margin_relaxed: float = 10.0 # мягкий запас
-
-	var coin_radius: float = 10.0
-	var min_coin_gap_strict: float = 40.0
-	var min_coin_gap_relaxed: float = 26.0
-
-	var exit_gap_strict: float = 80.0
-	var exit_gap_relaxed: float = 40.0
-
-	# Лерпим в зависимости от relax
-	var player_margin: float = lerp(player_margin_strict, player_margin_relaxed, relax)
-	var min_coin_gap: float = lerp(min_coin_gap_strict, min_coin_gap_relaxed, relax)
-	var exit_gap: float = lerp(exit_gap_strict, exit_gap_relaxed, relax)
-
-	# 1) Дистанция от старта игрока
-	if p.distance_to(LevelUtils.PLAYER_START) < (60.0 - 20.0 * relax):
-		return false
-
-	# 2) Препятствия: используем grow по Rect2 вместо полудиагонали
-	for obstacle in obstacles:
-		var r: Rect2 = LevelUtils.get_obstacle_rect(obstacle)
-		var grown := r.grow(player_margin + coin_radius)
-		if grown.has_point(p):
-			return false
-
-	# 3) Дистанция от других монет
-	for c in coins:
-		if p.distance_to(c.position) < min_coin_gap:
-			return false
-
-	# 4) Дистанция от выхода (и сравниваем корректно с ZERO)
-	if exit_pos != Vector2.ZERO:
-		if p.distance_to(exit_pos) < exit_gap:
-			return false
-
-	return true
-
 func clear_coins():
 	for coin in coins:
 		if is_instance_valid(coin):
 			coin.queue_free()
 	coins.clear()
 
-func _build_navigation_context(obstacles: Array) -> Dictionary:
-	var dimensions := LevelUtils.get_scaled_level_dimensions(current_level_size)
-	var level_width: float = float(dimensions.width)
-	var level_height: float = float(dimensions.height)
-	var offset := Vector2(dimensions.offset_x, dimensions.offset_y)
-	var cell_size := NAV_CELL_SIZE
-	var cols := int(ceil(level_width / cell_size))
-	var rows := int(ceil(level_height / cell_size))
+func _create_coin(grid_cols: int, grid_rows: int) -> Area2D:
+	var pos := LevelUtils.get_grid_position(current_level_size, grid_cols, grid_rows, 40, 30)
+	var coin := LevelNodeFactory.create_coin_node(coins.size(), pos)
+	coin.position = pos
+	return coin
 
-	var blocked: Array = []
-	for y in range(rows):
-		var row := []
-		row.resize(cols)
-		for x in range(cols):
-			row[x] = false
-		blocked.append(row)
-
-	var clearance := (PLAYER_DIAMETER * PATH_WIDTH_SCALE) * 0.5
-	var min_x := offset.x + clearance
-	var max_x := offset.x + level_width - clearance
-	var min_y := offset.y + clearance
-	var max_y := offset.y + level_height - clearance
-
-	for y in range(rows):
-		for x in range(cols):
-			var cell_center := offset + Vector2(float(x) + 0.5, float(y) + 0.5) * cell_size
-			if cell_center.x < min_x or cell_center.x > max_x or cell_center.y < min_y or cell_center.y > max_y:
-				blocked[y][x] = true
-
-	for obstacle in obstacles:
-		var rect := LevelUtils.get_obstacle_rect(obstacle)
-		_mark_rect_blocked(blocked, rect, offset, cols, rows, cell_size, clearance)
-
-	return {
-		"blocked": blocked,
-		"cols": cols,
-		"rows": rows,
-		"cell_size": cell_size,
-		"offset": offset
-	}
-
-func _mark_rect_blocked(blocked: Array, rect: Rect2, offset: Vector2, cols: int, rows: int, cell_size: float, clearance: float) -> void:
-	var expanded := rect.grow(clearance)
-	var min_col := int(floor((expanded.position.x - offset.x) / cell_size))
-	var max_col := int(ceil((expanded.position.x + expanded.size.x - offset.x) / cell_size)) - 1
-	var min_row := int(floor((expanded.position.y - offset.y) / cell_size))
-	var max_row := int(ceil((expanded.position.y + expanded.size.y - offset.y) / cell_size)) - 1
-
-	for y in range(max(min_row, 0), min(max_row, rows - 1) + 1):
-		for x in range(max(min_col, 0), min(max_col, cols - 1) + 1):
-			blocked[y][x] = true
-
-func _has_clear_path(navigation_ctx: Dictionary, start: Vector2, goal: Vector2) -> bool:
-	if navigation_ctx.is_empty():
-		return true
-
-	var start_cell := _world_to_cell(navigation_ctx, start)
-	var goal_cell := _world_to_cell(navigation_ctx, goal)
-
-	if not _cell_in_bounds(navigation_ctx, start_cell) or not _cell_in_bounds(navigation_ctx, goal_cell):
-		return false
-
-	var blocked: Array = navigation_ctx["blocked"]
-	if blocked[goal_cell.y][goal_cell.x]:
-		return false
-
-	if blocked[start_cell.y][start_cell.x]:
-		blocked[start_cell.y][start_cell.x] = false
-
-	var rows: int = navigation_ctx["rows"]
-	var cols: int = navigation_ctx["cols"]
-	var visited: Array = []
-	for y in range(rows):
-		var row := []
-		row.resize(cols)
-		for x in range(cols):
-			row[x] = false
-		visited.append(row)
-
-	var queue: Array = []
-	queue.append(start_cell)
-	visited[start_cell.y][start_cell.x] = true
-
-	while not queue.is_empty():
-		var cell: Vector2i = queue.pop_front()
-		if cell == goal_cell:
-			return true
-
-		for neighbor in _get_neighbors(cell):
-			if not _cell_in_bounds(navigation_ctx, neighbor):
-				continue
-			if visited[neighbor.y][neighbor.x]:
-				continue
-			if blocked[neighbor.y][neighbor.x]:
-				continue
-			if abs(neighbor.x - cell.x) == 1 and abs(neighbor.y - cell.y) == 1:
-				if blocked[cell.y][neighbor.x] or blocked[neighbor.y][cell.x]:
-					continue
-			visited[neighbor.y][neighbor.x] = true
-			queue.append(neighbor)
-
-	return false
-
-func _world_to_cell(navigation_ctx: Dictionary, point: Vector2) -> Vector2i:
-	var offset: Vector2 = navigation_ctx["offset"]
-	var cell_size: float = navigation_ctx["cell_size"]
-	var x := int(floor((point.x - offset.x) / cell_size))
-	var y := int(floor((point.y - offset.y) / cell_size))
-	return Vector2i(x, y)
-
-func _cell_in_bounds(navigation_ctx: Dictionary, cell: Vector2i) -> bool:
-	return cell.x >= 0 and cell.x < navigation_ctx["cols"] and cell.y >= 0 and cell.y < navigation_ctx["rows"]
-
-func _get_neighbors(cell: Vector2i) -> Array:
-	return [
-		cell + Vector2i(1, 0),
-		cell + Vector2i(-1, 0),
-		cell + Vector2i(0, 1),
-		cell + Vector2i(0, -1),
-		cell + Vector2i(1, 1),
-		cell + Vector2i(1, -1),
-		cell + Vector2i(-1, 1),
-		cell + Vector2i(-1, -1)
-	]
+func _add_coin(coin: Area2D, main_scene) -> void:
+	coins.append(coin)
+	if main_scene:
+		main_scene.call_deferred("add_child", coin)
+	else:
+		get_tree().current_scene.call_deferred("add_child", coin)

--- a/scripts/LevelGenerator.gd
+++ b/scripts/LevelGenerator.gd
@@ -1,15 +1,23 @@
 extends Node2D
 
 const Logger = preload("res://scripts/Logger.gd")
+const MazeGenerator = preload("res://scripts/level_generators/MazeGenerator.gd")
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+const GameState = preload("res://scripts/GameState.gd")
+const KeyLevelGenerator = preload("res://scripts/level_generators/KeyLevelGenerator.gd")
+const ObstacleUtilities = preload("res://scripts/level_generators/ObstacleUtilities.gd")
 
 const DOOR_GROUP_COLORS := [
-	Color(0.95, 0.49, 0.38, 1.0), # Coral
-	Color(0.41, 0.68, 0.95, 1.0), # Sky blue
-	Color(0.55, 0.83, 0.42, 1.0), # Green
-	Color(0.95, 0.75, 0.35, 1.0), # Amber
-	Color(0.74, 0.56, 0.95, 1.0), # Violet
-	Color(0.37, 0.82, 0.74, 1.0)  # Teal
+	Color(0.95, 0.49, 0.38, 1.0),
+	Color(0.41, 0.68, 0.95, 1.0),
+	Color(0.55, 0.83, 0.42, 1.0),
+	Color(0.95, 0.75, 0.35, 1.0),
+	Color(0.74, 0.56, 0.95, 1.0),
+	Color(0.37, 0.82, 0.74, 1.0)
 ]
+
+const MAZE_BASE_CELL_SIZE := 64.0
+const MAZE_WALL_SIZE_RATIO := 0.5
 
 var obstacles: Array = []
 var coins: Array = []
@@ -24,35 +32,46 @@ var player_spawn_override: Vector2 = Vector2.ZERO
 var has_player_spawn_override: bool = false
 var last_maze_path_length: float = 0.0
 
-const MAZE_BASE_CELL_SIZE := 64.0
-const MAZE_WALL_SIZE_RATIO := 0.5
-
-# Spawner nodes
 @onready var obstacle_spawner = $ObstacleSpawner
 @onready var coin_spawner = $CoinSpawner
 @onready var exit_spawner = $ExitSpawner
+
+var maze_generator
+var key_level_generator
+var obstacle_utils
+
+func _ready():
+	_ensure_helpers()
+
+func _ensure_helpers() -> void:
+	if obstacle_utils == null:
+		obstacle_utils = ObstacleUtilities.new(self)
+	if maze_generator == null:
+		maze_generator = MazeGenerator.new(self, obstacle_utils)
+	if key_level_generator == null:
+		key_level_generator = KeyLevelGenerator.new(self, obstacle_utils)
 
 func generate_level(level_size := 1.0, generate_obstacles := true, generate_coins := true, min_exit_distance_ratio := 0.4, use_full_map_coverage := true, main_scene: Node = null, level := 1, preserved_coin_count := 0, player_start_position: Vector2 = LevelUtils.PLAYER_START, level_type: int = GameState.LevelType.OBSTACLES_COINS):
 	Logger.log_generation("LevelGenerator starting (size %.2f, type %d)" % [level_size, level_type])
 	current_level_size = level_size
 	exit_pos = Vector2.ZERO
 	last_maze_path_length = 0.0
+	_ensure_helpers()
 	clear_existing_objects()
 	match level_type:
 		GameState.LevelType.KEYS:
-			_generate_keys_level(main_scene, level, player_start_position)
+			key_level_generator.generate(main_scene, level, player_start_position)
 		GameState.LevelType.MAZE:
-			_generate_maze_level(false, main_scene, player_start_position)
+			maze_generator.generate_maze_level(false, main_scene, player_start_position)
 		GameState.LevelType.MAZE_COINS:
-			_generate_maze_level(true, main_scene, player_start_position)
+			maze_generator.generate_maze_level(true, main_scene, player_start_position)
 		GameState.LevelType.MAZE_KEYS:
-			_generate_maze_keys_level(main_scene, level, player_start_position)
+			maze_generator.generate_maze_keys_level(main_scene, level, player_start_position)
 		_:
 			_generate_standard_level(level_size, generate_obstacles, generate_coins, min_exit_distance_ratio, use_full_map_coverage, main_scene, level, preserved_coin_count, player_start_position)
 	return 0
 
 func _generate_standard_level(level_size: float, generate_obstacles: bool, generate_coins_flag: bool, min_exit_distance_ratio: float, use_full_map_coverage: bool, main_scene, level: int, preserved_coin_count: int, player_start_position: Vector2) -> void:
-	# Step 1: Generate obstacles first (if enabled)
 	if generate_obstacles:
 		if obstacle_spawner and is_instance_valid(obstacle_spawner):
 			obstacles = obstacle_spawner.generate_obstacles(level_size, use_full_map_coverage, main_scene, level)
@@ -66,7 +85,6 @@ func _generate_standard_level(level_size: float, generate_obstacles: bool, gener
 	else:
 		Logger.log_generation("Obstacle generation disabled for this level")
 
-	# Step 2: Generate exit
 	if exit_spawner and is_instance_valid(exit_spawner):
 		var exit_node = exit_spawner.generate_exit(level_size, obstacles, min_exit_distance_ratio, main_scene)
 		if exit_node:
@@ -76,7 +94,6 @@ func _generate_standard_level(level_size: float, generate_obstacles: bool, gener
 	else:
 		Logger.log_error("ExitSpawner reference missing")
 
-	# Step 3: Generate coins
 	if generate_coins_flag:
 		if coin_spawner and is_instance_valid(coin_spawner):
 			coins = coin_spawner.generate_coins(level_size, obstacles, exit_pos, player_start_position, use_full_map_coverage, main_scene, level, preserved_coin_count)
@@ -89,287 +106,6 @@ func _generate_standard_level(level_size: float, generate_obstacles: bool, gener
 			coins = coin_spawner.generate_coins(level_size, obstacles, exit_pos, player_start_position, use_full_map_coverage, main_scene, level, preserved_coin_count)
 	else:
 		Logger.log_generation("Coin generation disabled for this level")
-
-func _generate_keys_level(main_scene, level: int, player_start_position: Vector2) -> void:
-	var dims = LevelUtils.get_scaled_level_dimensions(current_level_size)
-	var level_width: float = float(dims.width)
-	var level_height: float = float(dims.height)
-	var offset = Vector2(dims.offset_x, dims.offset_y)
-
-	var max_doors = clamp(1 + int(ceil(level / 2.0)), 1, 3)
-	var door_count = randi_range(1, max_doors)
-	var door_width = 48.0
-	var max_gap_height = max(level_height - 200.0, 140.0)
-	var door_gap_height = clamp(level_height * 0.35, 140.0, max_gap_height)
-	var segment_width = level_width / float(door_count + 1)
-
-	var door_states: Array = []
-	for i in range(door_count):
-		door_states.append(true)
-	if door_count > 1 and randi_range(0, 100) < 35:
-		var open_index = randi_range(0, door_count - 1)
-		door_states[open_index] = false
-
-	var closed_indices: Array = []
-	for i in range(door_count):
-		if door_states[i]:
-			closed_indices.append(i)
-	if closed_indices.is_empty():
-		door_states[0] = true
-		closed_indices.append(0)
-
-	var min_keys = max(2, closed_indices.size())
-	var max_keys = 6
-	var key_total = randi_range(min_keys, max_keys)
-	var keys_per_door := {}
-	for i in range(door_count):
-		keys_per_door[i] = 0
-	var remaining = key_total
-	for idx in closed_indices:
-		keys_per_door[idx] = 1
-		remaining -= 1
-	while remaining > 0 and closed_indices.size() > 0:
-		var idx = closed_indices[randi() % closed_indices.size()]
-		keys_per_door[idx] += 1
-		remaining -= 1
-
-	var door_layouts: Array = []
-	for i in range(door_count):
-		var center_x = offset.x + segment_width * float(i + 1)
-		var min_center_y = offset.y + door_gap_height * 0.5 + 60.0
-		var max_center_y = offset.y + level_height - door_gap_height * 0.5 - 60.0
-		if max_center_y <= min_center_y:
-			min_center_y = offset.y + level_height * 0.5
-			max_center_y = min_center_y
-		var door_center_y = randf_range(min_center_y, max_center_y)
-		var door_top = door_center_y - door_gap_height * 0.5
-		var layout := {
-			"index": i,
-			"center_x": center_x,
-			"door_top": door_top,
-			"door_bottom": door_top + door_gap_height,
-			"keys_needed": int(keys_per_door[i]),
-			"initially_open": not door_states[i],
-			"color": _get_group_color(i)
-		}
-		door_layouts.append(layout)
-
-	var spawn_y = clamp(player_start_position.y, offset.y + 80.0, offset.y + level_height - 80.0)
-	var spawn_override = Vector2(offset.x + 80.0, spawn_y)
-	_generate_key_level_obstacles(current_level_size, main_scene, level, offset, level_width, level_height, door_layouts, door_width, spawn_override)
-
-	exit_spawner.clear_exit()
-	coins.clear()
-	var door_positions: Array = []
-	var key_positions: Array = []
-	var door_group_colors: Array = []
-	for layout in door_layouts:
-		var i = int(layout.get("index", 0))
-		var center_x = float(layout.get("center_x", offset.x))
-		door_positions.append(center_x)
-		var door_top = float(layout.get("door_top", offset.y))
-		var door_bottom = float(layout.get("door_bottom", door_top + door_gap_height))
-		var group_color: Color = layout.get("color", _get_group_color(i))
-		door_group_colors.append(group_color)
-		var initially_open = layout.get("initially_open", false)
-		var door = _create_door_node(i, int(layout.get("keys_needed", 0)), initially_open, door_gap_height, door_width, group_color)
-		door.position = Vector2(center_x - door_width * 0.5, door_top)
-		doors.append(door)
-		_add_generated_node(door, main_scene)
-
-		var top_segment_height = max(door_top - offset.y, 0.0)
-		if top_segment_height > 0.0:
-			var top_segment = _create_barrier_segment(door_width, top_segment_height)
-			top_segment.position = Vector2(center_x - door_width * 0.5, offset.y)
-			key_barriers.append(top_segment)
-			_add_generated_node(top_segment, main_scene)
-
-		var bottom_segment_height = max(offset.y + level_height - door_bottom, 0.0)
-		if bottom_segment_height > 0.0:
-			var bottom_segment = _create_barrier_segment(door_width, bottom_segment_height)
-			bottom_segment.position = Vector2(center_x - door_width * 0.5, door_bottom)
-			key_barriers.append(bottom_segment)
-			_add_generated_node(bottom_segment, main_scene)
-
-		var keys_needed = int(layout.get("keys_needed", 0))
-		if keys_needed <= 0:
-			continue
-
-		var segment_left: float
-		if i == 0:
-			segment_left = offset.x + 60.0
-		else:
-			segment_left = door_positions[i - 1] + door_width * 0.5 + 60.0
-		var segment_right = center_x - door_width * 0.5 - 60.0
-		if segment_right <= segment_left:
-			segment_right = segment_left + 40.0
-		var min_y = offset.y + 80.0
-		var max_y = offset.y + level_height - 80.0
-
-		for j in range(keys_needed):
-			var attempts = 0
-			var key_pos = Vector2.ZERO
-			var placed = false
-			while attempts < 40 and not placed:
-				key_pos = Vector2(randf_range(segment_left, segment_right), randf_range(min_y, max_y))
-				var too_close = false
-				for existing in key_positions:
-					if existing.distance_to(key_pos) < 50.0:
-						too_close = true
-						break
-				if not too_close:
-					placed = true
-				else:
-					attempts += 1
-			if not placed:
-				key_pos = Vector2((segment_left + segment_right) * 0.5, offset.y + level_height * 0.5)
-			key_positions.append(key_pos)
-			var key_color = door_group_colors[i] if i < door_group_colors.size() else _get_group_color(i)
-			var key_node = _create_key_node(door, key_pos, keys_needed, key_color)
-			key_items.append(key_node)
-			_add_generated_node(key_node, main_scene)
-
-	_clear_obstacles_near_points(key_positions, 70.0)
-
-	var exit_position = Vector2(offset.x + level_width - 120.0, offset.y + level_height * 0.5)
-	exit_spawner.create_exit_at(exit_position, main_scene)
-	var exit_node = exit_spawner.get_exit()
-	if exit_node:
-		exit_pos = exit_node.position
-		_clear_obstacles_around_position(exit_pos, 100.0)
-
-	_set_player_spawn_override(spawn_override)
-
-func _generate_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
-	var dims = LevelUtils.get_scaled_level_dimensions(current_level_size)
-	var level_width: float = float(dims.width)
-	var level_height: float = float(dims.height)
-	var offset = Vector2(dims.offset_x, dims.offset_y)
-
-	var cell_size = MAZE_BASE_CELL_SIZE
-	var cols = int(floor(level_width / cell_size))
-	var rows = int(floor(level_height / cell_size))
-	cols = max(cols | 1, 5)
-	rows = max(rows | 1, 5)
-	var maze_width = cols * cell_size
-	var maze_height = rows * cell_size
-	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
-
-	var start_cell = _world_to_maze_cell(player_start_position, maze_offset, cell_size)
-	start_cell = _ensure_odd_cell(start_cell, cols, rows)
-
-	var grid = _init_maze_grid(cols, rows)
-	_carve_maze(grid, start_cell, cols, rows)
-	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
-
-	var farthest_data = _find_farthest_cell(grid, start_cell, cols, rows)
-	var farthest: Vector2i = farthest_data["cell"]
-	var path_steps: int = farthest_data["distance"]
-	last_maze_path_length = float(max(path_steps, 1)) * cell_size
-	var exit_position = _maze_cell_to_world(farthest, maze_offset, cell_size)
-	exit_spawner.clear_exit()
-	exit_spawner.create_exit_at(exit_position, main_scene)
-	var exit_node = exit_spawner.get_exit()
-	if exit_node:
-		exit_pos = exit_node.position
-
-	_set_player_spawn_override(_maze_cell_to_world(start_cell, maze_offset, cell_size))
-
-	coins.clear()
-	if include_coins:
-		_generate_maze_coins(grid, start_cell, farthest, maze_offset, cell_size, main_scene)
-
-func _generate_maze_keys_level(main_scene, level: int, player_start_position: Vector2) -> void:
-	var dims = LevelUtils.get_scaled_level_dimensions(current_level_size)
-	var level_width: float = float(dims.width)
-	var level_height: float = float(dims.height)
-	var offset = Vector2(dims.offset_x, dims.offset_y)
-
-	var cell_size = MAZE_BASE_CELL_SIZE
-	var cols = int(floor(level_width / cell_size))
-	var rows = int(floor(level_height / cell_size))
-	cols = max(cols | 1, 5)
-	rows = max(rows | 1, 5)
-	var maze_width = cols * cell_size
-	var maze_height = rows * cell_size
-	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
-
-	var start_cell = _world_to_maze_cell(player_start_position, maze_offset, cell_size)
-	start_cell = _ensure_odd_cell(start_cell, cols, rows)
-
-	var grid = _init_maze_grid(cols, rows)
-	_carve_maze(grid, start_cell, cols, rows)
-	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
-
-	var farthest_data = _find_farthest_cell(grid, start_cell, cols, rows)
-	var exit_cell: Vector2i = farthest_data["cell"]
-	var path_steps: int = farthest_data["distance"]
-	last_maze_path_length = float(max(path_steps, 1)) * cell_size
-
-	var path: Array = _reconstruct_maze_path(grid, start_cell, exit_cell, cols, rows)
-
-	coins.clear()
-	exit_spawner.clear_exit()
-
-	var exit_position = _maze_cell_to_world(exit_cell, maze_offset, cell_size)
-	exit_spawner.create_exit_at(exit_position, main_scene)
-	var exit_node = exit_spawner.get_exit()
-	if exit_node:
-		exit_pos = exit_node.position
-
-	var door_cell = exit_cell
-	if path.size() >= 2:
-		door_cell = path[path.size() - 2]
-	if door_cell == exit_cell and path.size() >= 3:
-		door_cell = path[path.size() - 3]
-
-	var desired_keys = clamp(2 + int(floor(level / 2.0)), 2, 6)
-	var key_cells: Array = _pick_maze_key_cells(grid, path, start_cell, door_cell, exit_cell, desired_keys)
-	var actual_keys = key_cells.size()
-	var door_required = actual_keys
-	var door_color = _get_group_color(0)
-	var door_initially_open = door_required <= 0
-
-	var door = _create_door_node(0, door_required, door_initially_open, cell_size, cell_size, door_color)
-	door.position = maze_offset + Vector2(door_cell.x * cell_size, door_cell.y * cell_size)
-	doors.append(door)
-	_add_generated_node(door, main_scene)
-
-	if actual_keys > 0:
-		for cell in key_cells:
-			var key_pos = _maze_cell_to_world(cell, maze_offset, cell_size)
-			var key_node = _create_key_node(door, key_pos, door_required, door_color)
-			key_items.append(key_node)
-			_add_generated_node(key_node, main_scene)
-
-	Logger.log_generation("Maze+Keys door at %s with %d keys" % [str(door_cell), actual_keys])
-	_set_player_spawn_override(_maze_cell_to_world(start_cell, maze_offset, cell_size))
-
-func _generate_maze_coins(grid: Array, start: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, main_scene) -> void:
-	var rows = grid.size()
-	var cols = grid[0].size()
-	var candidates: Array = []
-	for y in range(rows):
-		for x in range(cols):
-			if grid[y][x]:
-				continue
-			var cell = Vector2i(x, y)
-			if cell == start or cell == exit_cell:
-				continue
-			if (abs(cell.x - start.x) + abs(cell.y - start.y)) < 3:
-				continue
-			candidates.append(cell)
-	candidates.shuffle()
-	var desired = clamp(int(candidates.size() / 8.0), 5, 20)
-	for i in range(min(desired, candidates.size())):
-		var cell = candidates[i]
-		var world_pos = _maze_cell_to_world(cell, offset, cell_size)
-		var coin = _create_coin_node(world_pos)
-		coins.append(coin)
-		if main_scene:
-			main_scene.call_deferred("add_child", coin)
-		else:
-			call_deferred("add_child", coin)
 
 func get_generated_coins():
 	return coins
@@ -431,11 +167,11 @@ func clear_existing_objects():
 	has_player_spawn_override = false
 	player_spawn_override = Vector2.ZERO
 
-func _set_player_spawn_override(pos: Vector2) -> void:
+func set_player_spawn_override(pos: Vector2) -> void:
 	has_player_spawn_override = true
 	player_spawn_override = pos
 
-func _add_generated_node(node: Node, main_scene) -> void:
+func add_generated_node(node: Node, main_scene) -> void:
 	if node == null:
 		return
 	if main_scene:
@@ -443,384 +179,7 @@ func _add_generated_node(node: Node, main_scene) -> void:
 	else:
 		call_deferred("add_child", node)
 
-func _create_door_node(index: int, required_keys: int, initially_open: bool, height: float, width: float, group_color: Color) -> StaticBody2D:
-	var door := StaticBody2D.new()
-	door.name = "Door%d" % index
-	door.set_script(preload("res://scripts/Door.gd"))
-	door.required_keys = required_keys
-	door.initially_open = initially_open
-	door.door_id = index
-	door.door_color = group_color
-	door.set_meta("group_color", group_color)
-
-	var body := ColorRect.new()
-	body.name = "DoorBody"
-	body.offset_right = width
-	body.offset_bottom = height
-	body.color = group_color
-	door.add_child(body)
-
-	var collision := CollisionShape2D.new()
-	collision.name = "DoorCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(width, height)
-	collision.shape = shape
-	collision.position = Vector2(width * 0.5, height * 0.5)
-	door.add_child(collision)
-
-	return door
-
-func _create_barrier_segment(width: float, height: float) -> StaticBody2D:
-	var barrier := StaticBody2D.new()
-	barrier.name = "DoorBarrier%d" % key_barriers.size()
-
-	var body := ColorRect.new()
-	body.name = "BarrierBody"
-	body.offset_right = width
-	body.offset_bottom = height
-	body.color = Color(0.18, 0.21, 0.32, 1)
-	barrier.add_child(body)
-
-	var collision := CollisionShape2D.new()
-	collision.name = "BarrierCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(width, height)
-	collision.shape = shape
-	collision.position = Vector2(width * 0.5, height * 0.5)
-	barrier.add_child(collision)
-
-	return barrier
-
-func _create_key_node(door: StaticBody2D, spawn_position: Vector2, required_keys: int, key_color: Color) -> Area2D:
-	var key := Area2D.new()
-	key.name = "Key%d" % key_items.size()
-	key.position = spawn_position
-	key.set_script(preload("res://scripts/Key.gd"))
-	if door and door.is_inside_tree():
-		key.door_path = door.get_path()
-	else:
-		key.door_path = NodePath()
-	key.required_key_count = required_keys
-	key.door_reference = door
-	if door:
-		key.door_id = door.door_id
-	key.key_color = key_color
-	key.set_meta("group_color", key_color)
-
-	var body := ColorRect.new()
-	body.name = "KeyBody"
-	body.offset_right = 24
-	body.offset_bottom = 24
-	body.color = key_color
-	key.add_child(body)
-
-	var collision := CollisionShape2D.new()
-	collision.name = "KeyCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(24, 24)
-	collision.shape = shape
-	collision.position = Vector2(12, 12)
-	key.add_child(collision)
-
-	return key
-
-func _generate_key_level_obstacles(level_size: float, main_scene, level: int, offset: Vector2, level_width: float, level_height: float, door_layouts: Array, door_width: float, spawn_override: Vector2) -> void:
-	if obstacle_spawner == null or not is_instance_valid(obstacle_spawner):
-		Logger.log_error("ObstacleSpawner unavailable for key level")
-		return
-
-	obstacles = obstacle_spawner.generate_obstacles(level_size, true, main_scene, level)
-	if obstacles.is_empty():
-		return
-
-	var door_margin = 60.0
-	var clearance_rects: Array = []
-	for layout in door_layouts:
-		if typeof(layout) != TYPE_DICTIONARY:
-			continue
-		var center_x = float(layout.get("center_x", offset.x))
-		var rect_position = Vector2(center_x - (door_width * 0.5 + door_margin), offset.y)
-		var rect_size = Vector2(door_width + door_margin * 2.0, level_height)
-		clearance_rects.append(Rect2(rect_position, rect_size))
-
-	if not clearance_rects.is_empty():
-		_clear_obstacles_in_rects(clearance_rects)
-
-	if spawn_override != Vector2.ZERO:
-		_clear_obstacles_around_position(spawn_override, 140.0)
-
-func _clear_obstacles_in_rects(rects: Array) -> void:
-	if obstacles.is_empty():
-		return
-
-	var to_remove: Array = []
-	for obstacle in obstacles:
-		if not is_instance_valid(obstacle):
-			if not to_remove.has(obstacle):
-				to_remove.append(obstacle)
-			continue
-		var obstacle_rect = LevelUtils.get_obstacle_rect(obstacle)
-		for rect in rects:
-			if rect is Rect2 and obstacle_rect.intersects(rect):
-				if not to_remove.has(obstacle):
-					to_remove.append(obstacle)
-				break
-
-	_remove_obstacles(to_remove)
-
-func _clear_obstacles_near_points(points: Array, radius: float) -> void:
-	if obstacles.is_empty() or points.is_empty() or radius <= 0.0:
-		return
-
-	var radius_sq = radius * radius
-	var to_remove: Array = []
-	for obstacle in obstacles:
-		if not is_instance_valid(obstacle):
-			if not to_remove.has(obstacle):
-				to_remove.append(obstacle)
-			continue
-		for point in points:
-			if typeof(point) != TYPE_VECTOR2:
-				continue
-			if obstacle.position.distance_squared_to(point) <= radius_sq:
-				if not to_remove.has(obstacle):
-					to_remove.append(obstacle)
-				break
-
-	_remove_obstacles(to_remove)
-
-func _clear_obstacles_around_position(position: Vector2, radius: float) -> void:
-	if radius <= 0.0:
-		return
-	_clear_obstacles_near_points([position], radius)
-
-func _remove_obstacles(obstacles_to_remove: Array) -> void:
-	if obstacles_to_remove.is_empty():
-		return
-
-	var spawner_obstacles: Array = []
-	if obstacle_spawner and is_instance_valid(obstacle_spawner):
-		spawner_obstacles = obstacle_spawner.get_obstacles()
-
-	for obstacle in obstacles_to_remove:
-		if obstacle == null:
-			continue
-		if obstacles.has(obstacle):
-			obstacles.erase(obstacle)
-		if spawner_obstacles and spawner_obstacles.has(obstacle):
-			spawner_obstacles.erase(obstacle)
-		if is_instance_valid(obstacle):
-			obstacle.queue_free()
-
-func _get_group_color(index: int) -> Color:
+func get_group_color(index: int) -> Color:
 	if DOOR_GROUP_COLORS.is_empty():
 		return Color(0.9, 0.9, 0.2, 1.0)
 	return DOOR_GROUP_COLORS[index % DOOR_GROUP_COLORS.size()]
-
-func _create_coin_node(spawn_position: Vector2) -> Area2D:
-	var coin := Area2D.new()
-	coin.name = "Coin" + str(coins.size())
-	coin.position = spawn_position
-
-	var body := ColorRect.new()
-	body.name = "CoinBody"
-	body.offset_right = 20
-	body.offset_bottom = 20
-	body.color = Color(1, 1, 0, 1)
-	coin.add_child(body)
-
-	var collision := CollisionShape2D.new()
-	collision.name = "CoinCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(20, 20)
-	collision.shape = shape
-	collision.position = Vector2(10, 10)
-	coin.add_child(collision)
-
-	return coin
-
-func _create_maze_wall(cell_size: float) -> StaticBody2D:
-	var wall := StaticBody2D.new()
-	wall.name = "MazeWall" + str(maze_walls.size())
-
-	var thickness := cell_size * MAZE_WALL_SIZE_RATIO
-	var inset := (cell_size - thickness) * 0.5
-
-	var body := ColorRect.new()
-	body.name = "WallBody"
-	body.offset_left = inset
-	body.offset_top = inset
-	body.offset_right = inset + thickness
-	body.offset_bottom = inset + thickness
-	body.color = Color(0.15, 0.18, 0.28, 1)
-	wall.add_child(body)
-
-	var collision := CollisionShape2D.new()
-	collision.name = "WallCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(thickness, thickness)
-	collision.shape = shape
-	collision.position = Vector2(cell_size * 0.5, cell_size * 0.5)
-	wall.add_child(collision)
-
-	return wall
-
-func _init_maze_grid(cols: int, rows: int) -> Array:
-	var grid: Array = []
-	for y in range(rows):
-		var row := []
-		row.resize(cols)
-		for x in range(cols):
-			row[x] = true
-		grid.append(row)
-	return grid
-
-func _carve_maze(grid: Array, cell: Vector2i, cols: int, rows: int) -> void:
-	grid[cell.y][cell.x] = false
-	var directions = [Vector2i(2, 0), Vector2i(-2, 0), Vector2i(0, 2), Vector2i(0, -2)]
-	directions.shuffle()
-	for dir in directions:
-		var next = cell + dir
-		if next.x <= 0 or next.x >= cols - 1 or next.y <= 0 or next.y >= rows - 1:
-			continue
-		if grid[next.y][next.x]:
-			var between = cell + Vector2i(dir.x / 2, dir.y / 2)
-			grid[between.y][between.x] = false
-			_carve_maze(grid, next, cols, rows)
-
-func _spawn_maze_walls(grid: Array, offset: Vector2, cell_size: float, main_scene) -> void:
-	var rows = grid.size()
-	var cols = grid[0].size()
-	for y in range(rows):
-		for x in range(cols):
-			if grid[y][x]:
-				var wall = _create_maze_wall(cell_size)
-				wall.position = offset + Vector2(x * cell_size, y * cell_size)
-				maze_walls.append(wall)
-				if main_scene:
-					main_scene.call_deferred("add_child", wall)
-				else:
-					call_deferred("add_child", wall)
-
-func _find_farthest_cell(grid: Array, start: Vector2i, cols: int, rows: int) -> Dictionary:
-	var visited: Array = []
-	for y in range(rows):
-		var row := []
-		row.resize(cols)
-		for x in range(cols):
-			row[x] = false
-		visited.append(row)
-	var queue: Array = []
-	queue.append({"cell": start, "dist": 0})
-	visited[start.y][start.x] = true
-	var farthest = start
-	var max_dist = 0
-	while not queue.is_empty():
-		var item = queue.pop_front()
-		var cell: Vector2i = item["cell"]
-		var dist: int = item["dist"]
-		if dist > max_dist:
-			max_dist = dist
-			farthest = cell
-		for dir in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
-			var next = cell + dir
-			if next.x < 0 or next.x >= cols or next.y < 0 or next.y >= rows:
-				continue
-			if grid[next.y][next.x] or visited[next.y][next.x]:
-				continue
-			visited[next.y][next.x] = true
-			queue.append({"cell": next, "dist": dist + 1})
-	return {"cell": farthest, "distance": max_dist}
-
-func _reconstruct_maze_path(grid: Array, start: Vector2i, goal: Vector2i, cols: int, rows: int) -> Array:
-	var visited: Dictionary = {}
-	var parents: Dictionary = {}
-	var queue: Array = []
-	queue.append(start)
-	visited[start] = true
-	while not queue.is_empty():
-		var cell: Vector2i = queue.pop_front()
-		if cell == goal:
-			break
-		for dir in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
-			var next = cell + dir
-			if next.x < 0 or next.x >= cols or next.y < 0 or next.y >= rows:
-				continue
-			if grid[next.y][next.x] or visited.has(next):
-				continue
-			visited[next] = true
-			parents[next] = cell
-			queue.append(next)
-	var path: Array = []
-	if not visited.has(goal):
-		path.append(start)
-		return path
-	var current = goal
-	while true:
-		path.push_front(current)
-		if current == start:
-			break
-		if not parents.has(current):
-			break
-		current = parents[current]
-	return path
-
-func _pick_maze_key_cells(grid: Array, path: Array, start_cell: Vector2i, door_cell: Vector2i, exit_cell: Vector2i, desired: int) -> Array:
-	var result: Array = []
-	if desired <= 0:
-		return result
-	var path_candidates: Array = []
-	for cell_variant in path:
-		var cell: Vector2i = cell_variant
-		if cell == start_cell or cell == door_cell or cell == exit_cell:
-			continue
-		if path_candidates.has(cell):
-			continue
-		path_candidates.append(cell)
-	path_candidates.shuffle()
-	for cell in path_candidates:
-		if result.size() >= desired:
-			break
-		result.append(cell)
-	if result.size() >= desired:
-		return result
-	var rows = grid.size()
-	if rows <= 0:
-		return result
-	var cols = grid[0].size() if rows > 0 else 0
-	var extras: Array = []
-	for y in range(rows):
-		for x in range(cols):
-			if grid[y][x]:
-				continue
-			var candidate = Vector2i(x, y)
-			if candidate == start_cell or candidate == door_cell or candidate == exit_cell:
-				continue
-			if result.has(candidate):
-				continue
-			extras.append(candidate)
-	extras.shuffle()
-	for cell in extras:
-		if result.size() >= desired:
-			break
-		result.append(cell)
-	return result
-
-func _maze_cell_to_world(cell: Vector2i, offset: Vector2, cell_size: float) -> Vector2:
-	return offset + Vector2(cell.x * cell_size + cell_size * 0.5, cell.y * cell_size + cell_size * 0.5)
-
-func _world_to_maze_cell(world: Vector2, offset: Vector2, cell_size: float) -> Vector2i:
-	var x = int(floor((world.x - offset.x) / cell_size))
-	var y = int(floor((world.y - offset.y) / cell_size))
-	return Vector2i(x, y)
-
-func _ensure_odd_cell(cell: Vector2i, cols: int, rows: int) -> Vector2i:
-	var result = cell
-	result.x = clamp(result.x, 1, cols - 2)
-	result.y = clamp(result.y, 1, rows - 2)
-	if result.x % 2 == 0:
-		result.x += 1 if (result.x + 1 < cols) else -1
-	if result.y % 2 == 0:
-		result.y += 1 if (result.y + 1 < rows) else -1
-	return result
-

--- a/scripts/coin/CoinNavigation.gd
+++ b/scripts/coin/CoinNavigation.gd
@@ -1,0 +1,128 @@
+extends Object
+class_name CoinNavigation
+
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+
+static func build_navigation_context(level_size: float, obstacles: Array, cell_size: float, player_diameter: float, path_width_scale: float) -> Dictionary:
+	var dimensions := LevelUtils.get_scaled_level_dimensions(level_size)
+	var level_width: float = float(dimensions.width)
+	var level_height: float = float(dimensions.height)
+	var offset := Vector2(dimensions.offset_x, dimensions.offset_y)
+	var cols := int(ceil(level_width / cell_size))
+	var rows := int(ceil(level_height / cell_size))
+
+	var blocked: Array = []
+	for y in range(rows):
+		var row := []
+		row.resize(cols)
+		for x in range(cols):
+			row[x] = false
+		blocked.append(row)
+
+	var clearance := (player_diameter * path_width_scale) * 0.5
+	var min_x := offset.x + clearance
+	var max_x := offset.x + level_width - clearance
+	var min_y := offset.y + clearance
+	var max_y := offset.y + level_height - clearance
+
+	for y in range(rows):
+		for x in range(cols):
+			var cell_center := offset + Vector2(float(x) + 0.5, float(y) + 0.5) * cell_size
+			if cell_center.x < min_x or cell_center.x > max_x or cell_center.y < min_y or cell_center.y > max_y:
+				blocked[y][x] = true
+
+	for obstacle in obstacles:
+		var rect := LevelUtils.get_obstacle_rect(obstacle)
+		_mark_rect_blocked(blocked, rect, offset, cols, rows, cell_size, clearance)
+
+	return {
+		"blocked": blocked,
+		"cols": cols,
+		"rows": rows,
+		"cell_size": cell_size,
+		"offset": offset
+	}
+
+static func has_clear_path(navigation_ctx: Dictionary, start: Vector2, goal: Vector2) -> bool:
+	if navigation_ctx.is_empty():
+		return true
+
+	var start_cell := _world_to_cell(navigation_ctx, start)
+	var goal_cell := _world_to_cell(navigation_ctx, goal)
+
+	if not _cell_in_bounds(navigation_ctx, start_cell) or not _cell_in_bounds(navigation_ctx, goal_cell):
+		return false
+
+	var blocked: Array = navigation_ctx["blocked"]
+	if blocked[goal_cell.y][goal_cell.x]:
+		return false
+
+	if blocked[start_cell.y][start_cell.x]:
+		blocked[start_cell.y][start_cell.x] = false
+
+	var rows: int = navigation_ctx["rows"]
+	var cols: int = navigation_ctx["cols"]
+	var visited: Array = []
+	for y in range(rows):
+		var row := []
+		row.resize(cols)
+		for x in range(cols):
+			row[x] = false
+		visited.append(row)
+
+	var queue: Array = []
+	queue.append(start_cell)
+	visited[start_cell.y][start_cell.x] = true
+
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		if cell == goal_cell:
+			return true
+
+		for neighbor in _get_neighbors(cell):
+			if not _cell_in_bounds(navigation_ctx, neighbor):
+				continue
+			if visited[neighbor.y][neighbor.x]:
+				continue
+			if blocked[neighbor.y][neighbor.x]:
+				continue
+			if abs(neighbor.x - cell.x) == 1 and abs(neighbor.y - cell.y) == 1:
+				if blocked[cell.y][neighbor.x] or blocked[neighbor.y][cell.x]:
+					continue
+			visited[neighbor.y][neighbor.x] = true
+			queue.append(neighbor)
+
+	return false
+
+static func _mark_rect_blocked(blocked: Array, rect: Rect2, offset: Vector2, cols: int, rows: int, cell_size: float, clearance: float) -> void:
+	var expanded := rect.grow(clearance)
+	var min_col := int(floor((expanded.position.x - offset.x) / cell_size))
+	var max_col := int(ceil((expanded.position.x + expanded.size.x - offset.x) / cell_size)) - 1
+	var min_row := int(floor((expanded.position.y - offset.y) / cell_size))
+	var max_row := int(ceil((expanded.position.y + expanded.size.y - offset.y) / cell_size)) - 1
+
+	for y in range(max(min_row, 0), min(max_row, rows - 1) + 1):
+		for x in range(max(min_col, 0), min(max_col, cols - 1) + 1):
+			blocked[y][x] = true
+
+static func _world_to_cell(navigation_ctx: Dictionary, point: Vector2) -> Vector2i:
+	var offset: Vector2 = navigation_ctx["offset"]
+	var cell_size: float = navigation_ctx["cell_size"]
+	var x := int(floor((point.x - offset.x) / cell_size))
+	var y := int(floor((point.y - offset.y) / cell_size))
+	return Vector2i(x, y)
+
+static func _cell_in_bounds(navigation_ctx: Dictionary, cell: Vector2i) -> bool:
+	return cell.x >= 0 and cell.x < navigation_ctx["cols"] and cell.y >= 0 and cell.y < navigation_ctx["rows"]
+
+static func _get_neighbors(cell: Vector2i) -> Array:
+	return [
+		cell + Vector2i(1, 0),
+		cell + Vector2i(-1, 0),
+		cell + Vector2i(0, 1),
+		cell + Vector2i(0, -1),
+		cell + Vector2i(1, 1),
+		cell + Vector2i(1, -1),
+		cell + Vector2i(-1, 1),
+		cell + Vector2i(-1, -1)
+	]

--- a/scripts/coin/CoinPlacementValidator.gd
+++ b/scripts/coin/CoinPlacementValidator.gd
@@ -1,0 +1,35 @@
+extends Object
+class_name CoinPlacementValidator
+
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+
+static func is_valid_position(position: Vector2, existing_coins: Array, obstacles: Array, exit_pos: Vector2, relax: float) -> bool:
+	var player_margin_strict: float = 24.0
+	var player_margin_relaxed: float = 10.0
+	var coin_radius: float = 10.0
+	var min_coin_gap_strict: float = 40.0
+	var min_coin_gap_relaxed: float = 26.0
+	var exit_gap_strict: float = 80.0
+	var exit_gap_relaxed: float = 40.0
+
+	var player_margin: float = lerp(player_margin_strict, player_margin_relaxed, relax)
+	var min_coin_gap: float = lerp(min_coin_gap_strict, min_coin_gap_relaxed, relax)
+	var exit_gap: float = lerp(exit_gap_strict, exit_gap_relaxed, relax)
+
+	if position.distance_to(LevelUtils.PLAYER_START) < (60.0 - 20.0 * relax):
+		return false
+
+	for obstacle in obstacles:
+		var rect: Rect2 = LevelUtils.get_obstacle_rect(obstacle)
+		var grown := rect.grow(player_margin + coin_radius)
+		if grown.has_point(position):
+			return false
+
+	for coin in existing_coins:
+		if position.distance_to(coin.position) < min_coin_gap:
+			return false
+
+	if exit_pos != Vector2.ZERO and position.distance_to(exit_pos) < exit_gap:
+		return false
+
+	return true

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -1,0 +1,190 @@
+extends RefCounted
+class_name KeyLevelGenerator
+
+const Logger = preload("res://scripts/Logger.gd")
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+const LevelNodeFactory = preload("res://scripts/level_generators/LevelNodeFactory.gd")
+
+const BARRIER_COLOR := Color(0.18, 0.21, 0.32, 1)
+
+var context
+var obstacle_utils
+
+func _init(level_context, obstacle_helper):
+	context = level_context
+	obstacle_utils = obstacle_helper
+
+func generate(main_scene, level: int, player_start_position: Vector2) -> void:
+	var dims = LevelUtils.get_scaled_level_dimensions(context.current_level_size)
+	var level_width: float = float(dims.width)
+	var level_height: float = float(dims.height)
+	var offset = Vector2(dims.offset_x, dims.offset_y)
+
+	var max_doors = clamp(1 + int(ceil(level / 2.0)), 1, 3)
+	var door_count = randi_range(1, max_doors)
+	var door_width = 48.0
+	var max_gap_height = max(level_height - 200.0, 140.0)
+	var door_gap_height = clamp(level_height * 0.35, 140.0, max_gap_height)
+	var segment_width = level_width / float(door_count + 1)
+
+	var door_states: Array = []
+	for i in range(door_count):
+		door_states.append(true)
+	if door_count > 1 and randi_range(0, 100) < 35:
+		var open_index = randi_range(0, door_count - 1)
+		door_states[open_index] = false
+
+	var closed_indices: Array = []
+	for i in range(door_count):
+		if door_states[i]:
+			closed_indices.append(i)
+	if closed_indices.is_empty():
+		door_states[0] = true
+		closed_indices.append(0)
+
+	var min_keys = max(2, closed_indices.size())
+	var max_keys = 6
+	var key_total = randi_range(min_keys, max_keys)
+	var keys_per_door := {}
+	for i in range(door_count):
+		keys_per_door[i] = 0
+	var remaining = key_total
+	for idx in closed_indices:
+		keys_per_door[idx] = 1
+		remaining -= 1
+	while remaining > 0 and closed_indices.size() > 0:
+		var idx = closed_indices[randi() % closed_indices.size()]
+		keys_per_door[idx] += 1
+		remaining -= 1
+
+	var door_layouts: Array = []
+	for i in range(door_count):
+		var center_x = offset.x + segment_width * float(i + 1)
+		var min_center_y = offset.y + door_gap_height * 0.5 + 60.0
+		var max_center_y = offset.y + level_height - door_gap_height * 0.5 - 60.0
+		if max_center_y <= min_center_y:
+			min_center_y = offset.y + level_height * 0.5
+			max_center_y = min_center_y
+		var door_center_y = randf_range(min_center_y, max_center_y)
+		var door_top = door_center_y - door_gap_height * 0.5
+		var layout := {
+			"index": i,
+			"center_x": center_x,
+			"door_top": door_top,
+			"door_bottom": door_top + door_gap_height,
+			"keys_needed": int(keys_per_door[i]),
+			"initially_open": not door_states[i],
+			"color": context.get_group_color(i)
+		}
+		door_layouts.append(layout)
+
+	var spawn_y = clamp(player_start_position.y, offset.y + 80.0, offset.y + level_height - 80.0)
+	var spawn_override = Vector2(offset.x + 80.0, spawn_y)
+	_generate_key_level_obstacles(context.current_level_size, main_scene, level, offset, level_width, level_height, door_layouts, door_width, spawn_override)
+
+	context.exit_spawner.clear_exit()
+	context.coins.clear()
+	var door_positions: Array = []
+	var key_positions: Array = []
+	var door_group_colors: Array = []
+	for layout in door_layouts:
+		var i = int(layout.get("index", 0))
+		var center_x = float(layout.get("center_x", offset.x))
+		door_positions.append(center_x)
+		var door_top = float(layout.get("door_top", offset.y))
+		var door_bottom = float(layout.get("door_bottom", door_top + door_gap_height))
+		var group_color: Color = layout.get("color", context.get_group_color(i))
+		door_group_colors.append(group_color)
+		var initially_open = layout.get("initially_open", false)
+		var door = LevelNodeFactory.create_door_node(i, int(layout.get("keys_needed", 0)), initially_open, door_gap_height, door_width, group_color)
+		door.position = Vector2(center_x - door_width * 0.5, door_top)
+		context.doors.append(door)
+		context.add_generated_node(door, main_scene)
+
+		var top_segment_height = max(door_top - offset.y, 0.0)
+		if top_segment_height > 0.0:
+			var top_segment = LevelNodeFactory.create_barrier_segment(context.key_barriers.size(), door_width, top_segment_height, BARRIER_COLOR)
+			top_segment.position = Vector2(center_x - door_width * 0.5, offset.y)
+			context.key_barriers.append(top_segment)
+			context.add_generated_node(top_segment, main_scene)
+
+		var bottom_segment_height = max(offset.y + level_height - door_bottom, 0.0)
+		if bottom_segment_height > 0.0:
+			var bottom_segment = LevelNodeFactory.create_barrier_segment(context.key_barriers.size(), door_width, bottom_segment_height, BARRIER_COLOR)
+			bottom_segment.position = Vector2(center_x - door_width * 0.5, door_bottom)
+			context.key_barriers.append(bottom_segment)
+			context.add_generated_node(bottom_segment, main_scene)
+
+		var keys_needed = int(layout.get("keys_needed", 0))
+		if keys_needed <= 0:
+			continue
+
+		var segment_left: float
+		if i == 0:
+			segment_left = offset.x + 60.0
+		else:
+			segment_left = door_positions[i - 1] + door_width * 0.5 + 60.0
+		var segment_right = center_x - door_width * 0.5 - 60.0
+		if segment_right <= segment_left:
+			segment_right = segment_left + 40.0
+		var min_y = offset.y + 80.0
+		var max_y = offset.y + level_height - 80.0
+
+		for j in range(keys_needed):
+			var attempts = 0
+			var key_pos = Vector2.ZERO
+			var placed = false
+			while attempts < 40 and not placed:
+				key_pos = Vector2(randf_range(segment_left, segment_right), randf_range(min_y, max_y))
+				var too_close = false
+				for existing in key_positions:
+					if existing.distance_to(key_pos) < 50.0:
+						too_close = true
+						break
+				if not too_close:
+					placed = true
+				else:
+					attempts += 1
+			if not placed:
+				key_pos = Vector2((segment_left + segment_right) * 0.5, offset.y + level_height * 0.5)
+			key_positions.append(key_pos)
+			var key_color = door_group_colors[i] if i < door_group_colors.size() else context.get_group_color(i)
+			var key_node = LevelNodeFactory.create_key_node(context.key_items.size(), door, key_pos, keys_needed, key_color)
+			context.key_items.append(key_node)
+			context.add_generated_node(key_node, main_scene)
+
+	obstacle_utils.clear_near_points(key_positions, 70.0)
+
+	var exit_position = Vector2(offset.x + level_width - 120.0, offset.y + level_height * 0.5)
+	context.exit_spawner.create_exit_at(exit_position, main_scene)
+	var exit_node = context.exit_spawner.get_exit()
+	if exit_node:
+		context.exit_pos = exit_node.position
+		obstacle_utils.clear_around_position(context.exit_pos, 100.0)
+
+	context.set_player_spawn_override(spawn_override)
+
+func _generate_key_level_obstacles(level_size: float, main_scene, level: int, offset: Vector2, level_width: float, level_height: float, door_layouts: Array, door_width: float, spawn_override: Vector2) -> void:
+	if context.obstacle_spawner == null or not is_instance_valid(context.obstacle_spawner):
+		Logger.log_error("ObstacleSpawner unavailable for key level")
+		return
+
+	context.obstacles = context.obstacle_spawner.generate_obstacles(level_size, true, main_scene, level)
+	if context.obstacles.is_empty():
+		return
+
+	var door_margin = 60.0
+	var clearance_rects: Array = []
+	for layout in door_layouts:
+		if typeof(layout) != TYPE_DICTIONARY:
+			continue
+		var center_x = float(layout.get("center_x", offset.x))
+		var rect_position = Vector2(center_x - (door_width * 0.5 + door_margin), offset.y)
+		var rect_size = Vector2(door_width + door_margin * 2.0, level_height)
+		clearance_rects.append(Rect2(rect_position, rect_size))
+
+	if not clearance_rects.is_empty():
+		obstacle_utils.clear_in_rects(clearance_rects)
+
+	if spawn_override != Vector2.ZERO:
+		obstacle_utils.clear_around_position(spawn_override, 140.0)

--- a/scripts/level_generators/LevelNodeFactory.gd
+++ b/scripts/level_generators/LevelNodeFactory.gd
@@ -1,0 +1,134 @@
+extends Object
+class_name LevelNodeFactory
+
+const DOOR_SCRIPT := preload("res://scripts/Door.gd")
+const KEY_SCRIPT := preload("res://scripts/Key.gd")
+
+static func create_door_node(index: int, required_keys: int, initially_open: bool, height: float, width: float, group_color: Color) -> StaticBody2D:
+	var door := StaticBody2D.new()
+	door.name = "Door%d" % index
+	door.set_script(DOOR_SCRIPT)
+	door.required_keys = required_keys
+	door.initially_open = initially_open
+	door.door_id = index
+	door.door_color = group_color
+	door.set_meta("group_color", group_color)
+
+	var body := ColorRect.new()
+	body.name = "DoorBody"
+	body.offset_right = width
+	body.offset_bottom = height
+	body.color = group_color
+	door.add_child(body)
+
+	var collision := CollisionShape2D.new()
+	collision.name = "DoorCollision"
+	var shape := RectangleShape2D.new()
+	shape.size = Vector2(width, height)
+	collision.shape = shape
+	collision.position = Vector2(width * 0.5, height * 0.5)
+	door.add_child(collision)
+
+	return door
+
+static func create_barrier_segment(name_index: int, width: float, height: float, color: Color) -> StaticBody2D:
+	var barrier := StaticBody2D.new()
+	barrier.name = "DoorBarrier%d" % name_index
+
+	var body := ColorRect.new()
+	body.name = "BarrierBody"
+	body.offset_right = width
+	body.offset_bottom = height
+	body.color = color
+	barrier.add_child(body)
+
+	var collision := CollisionShape2D.new()
+	collision.name = "BarrierCollision"
+	var shape := RectangleShape2D.new()
+	shape.size = Vector2(width, height)
+	collision.shape = shape
+	collision.position = Vector2(width * 0.5, height * 0.5)
+	barrier.add_child(collision)
+
+	return barrier
+
+static func create_key_node(name_index: int, door: StaticBody2D, spawn_position: Vector2, required_keys: int, key_color: Color) -> Area2D:
+	var key := Area2D.new()
+	key.name = "Key%d" % name_index
+	key.position = spawn_position
+	key.set_script(KEY_SCRIPT)
+	if door and door.is_inside_tree():
+		key.door_path = door.get_path()
+	else:
+		key.door_path = NodePath()
+	key.required_key_count = required_keys
+	key.door_reference = door
+	if door:
+		key.door_id = door.door_id
+	key.key_color = key_color
+	key.set_meta("group_color", key_color)
+
+	var body := ColorRect.new()
+	body.name = "KeyBody"
+	body.offset_right = 24
+	body.offset_bottom = 24
+	body.color = key_color
+	key.add_child(body)
+
+	var collision := CollisionShape2D.new()
+	collision.name = "KeyCollision"
+	var shape := RectangleShape2D.new()
+	shape.size = Vector2(24, 24)
+	collision.shape = shape
+	collision.position = Vector2(12, 12)
+	key.add_child(collision)
+
+	return key
+
+static func create_coin_node(name_index: int, spawn_position: Vector2) -> Area2D:
+	var coin := Area2D.new()
+	coin.name = "Coin" + str(name_index)
+	coin.position = spawn_position
+
+	var body := ColorRect.new()
+	body.name = "CoinBody"
+	body.offset_right = 20
+	body.offset_bottom = 20
+	body.color = Color(1, 1, 0, 1)
+	coin.add_child(body)
+
+	var collision := CollisionShape2D.new()
+	collision.name = "CoinCollision"
+	var shape := RectangleShape2D.new()
+	shape.size = Vector2(20, 20)
+	collision.shape = shape
+	collision.position = Vector2(10, 10)
+	coin.add_child(collision)
+
+	return coin
+
+static func create_maze_wall(name_index: int, cell_size: float, wall_color: Color, size_ratio: float) -> StaticBody2D:
+	var wall := StaticBody2D.new()
+	wall.name = "MazeWall" + str(name_index)
+
+	var thickness := cell_size * size_ratio
+	var inset := (cell_size - thickness) * 0.5
+
+	var body := ColorRect.new()
+	body.name = "WallBody"
+	body.offset_left = inset
+	body.offset_top = inset
+	body.offset_right = inset + thickness
+	body.offset_bottom = inset + thickness
+	body.color = wall_color
+	wall.add_child(body)
+
+	var collision := CollisionShape2D.new()
+	collision.name = "WallCollision"
+	var shape := RectangleShape2D.new()
+	shape.size = Vector2(thickness, thickness)
+	collision.shape = shape
+	collision.position = Vector2(cell_size * 0.5, cell_size * 0.5)
+	wall.add_child(collision)
+
+	return wall

--- a/scripts/level_generators/MazeGenerator.gd
+++ b/scripts/level_generators/MazeGenerator.gd
@@ -1,0 +1,152 @@
+extends RefCounted
+class_name MazeGenerator
+
+const Logger = preload("res://scripts/Logger.gd")
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+const MazeUtils = preload("res://scripts/level_generators/MazeUtils.gd")
+const LevelNodeFactory = preload("res://scripts/level_generators/LevelNodeFactory.gd")
+
+const WALL_COLOR := Color(0.15, 0.18, 0.28, 1)
+
+var context
+func _init(level_context, _obstacle_helper):
+	context = level_context
+
+func generate_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
+	var dims = LevelUtils.get_scaled_level_dimensions(context.current_level_size)
+	var level_width: float = float(dims.width)
+	var level_height: float = float(dims.height)
+	var offset = Vector2(dims.offset_x, dims.offset_y)
+
+	var cell_size = context.MAZE_BASE_CELL_SIZE
+	var cols = int(floor(level_width / cell_size))
+	var rows = int(floor(level_height / cell_size))
+	cols = max(cols | 1, 5)
+	rows = max(rows | 1, 5)
+	var maze_width = cols * cell_size
+	var maze_height = rows * cell_size
+	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
+
+	var start_cell = MazeUtils.world_to_maze_cell(player_start_position, maze_offset, cell_size)
+	start_cell = MazeUtils.ensure_odd_cell(start_cell, cols, rows)
+
+	var grid = MazeUtils.init_maze_grid(cols, rows)
+	MazeUtils.carve_maze(grid, start_cell, cols, rows)
+	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
+
+	var farthest_data = MazeUtils.find_farthest_cell(grid, start_cell, cols, rows)
+	var farthest: Vector2i = farthest_data["cell"]
+	var path_steps: int = farthest_data["distance"]
+	context.last_maze_path_length = float(max(path_steps, 1)) * cell_size
+	var exit_position = MazeUtils.maze_cell_to_world(farthest, maze_offset, cell_size)
+	context.exit_spawner.clear_exit()
+	context.exit_spawner.create_exit_at(exit_position, main_scene)
+	var exit_node = context.exit_spawner.get_exit()
+	if exit_node:
+		context.exit_pos = exit_node.position
+
+	context.set_player_spawn_override(MazeUtils.maze_cell_to_world(start_cell, maze_offset, cell_size))
+
+	context.coins.clear()
+	if include_coins:
+		_generate_maze_coins(grid, start_cell, farthest, maze_offset, cell_size, main_scene)
+
+func generate_maze_keys_level(main_scene, level: int, player_start_position: Vector2) -> void:
+	var dims = LevelUtils.get_scaled_level_dimensions(context.current_level_size)
+	var level_width: float = float(dims.width)
+	var level_height: float = float(dims.height)
+	var offset = Vector2(dims.offset_x, dims.offset_y)
+
+	var cell_size = context.MAZE_BASE_CELL_SIZE
+	var cols = int(floor(level_width / cell_size))
+	var rows = int(floor(level_height / cell_size))
+	cols = max(cols | 1, 5)
+	rows = max(rows | 1, 5)
+	var maze_width = cols * cell_size
+	var maze_height = rows * cell_size
+	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
+
+	var start_cell = MazeUtils.world_to_maze_cell(player_start_position, maze_offset, cell_size)
+	start_cell = MazeUtils.ensure_odd_cell(start_cell, cols, rows)
+
+	var grid = MazeUtils.init_maze_grid(cols, rows)
+	MazeUtils.carve_maze(grid, start_cell, cols, rows)
+	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
+
+	var farthest_data = MazeUtils.find_farthest_cell(grid, start_cell, cols, rows)
+	var exit_cell: Vector2i = farthest_data["cell"]
+	var path_steps: int = farthest_data["distance"]
+	context.last_maze_path_length = float(max(path_steps, 1)) * cell_size
+
+	var path: Array = MazeUtils.reconstruct_maze_path(grid, start_cell, exit_cell, cols, rows)
+
+	context.coins.clear()
+	context.exit_spawner.clear_exit()
+
+	var exit_position = MazeUtils.maze_cell_to_world(exit_cell, maze_offset, cell_size)
+	context.exit_spawner.create_exit_at(exit_position, main_scene)
+	var exit_node = context.exit_spawner.get_exit()
+	if exit_node:
+		context.exit_pos = exit_node.position
+
+	var door_cell = exit_cell
+	if path.size() >= 2:
+		door_cell = path[path.size() - 2]
+	if door_cell == exit_cell and path.size() >= 3:
+		door_cell = path[path.size() - 3]
+
+	var desired_keys = clamp(2 + int(floor(level / 2.0)), 2, 6)
+	var key_cells: Array = MazeUtils.pick_maze_key_cells(grid, path, start_cell, door_cell, exit_cell, desired_keys)
+	var actual_keys = key_cells.size()
+	var door_required = actual_keys
+	var door_color = context.get_group_color(0)
+	var door_initially_open = door_required <= 0
+
+	var door = LevelNodeFactory.create_door_node(0, door_required, door_initially_open, cell_size, cell_size, door_color)
+	door.position = maze_offset + Vector2(door_cell.x * cell_size, door_cell.y * cell_size)
+	context.doors.append(door)
+	context.add_generated_node(door, main_scene)
+
+	if actual_keys > 0:
+		for cell in key_cells:
+			var key_pos = MazeUtils.maze_cell_to_world(cell, maze_offset, cell_size)
+			var key_node = LevelNodeFactory.create_key_node(context.key_items.size(), door, key_pos, door_required, door_color)
+			context.key_items.append(key_node)
+			context.add_generated_node(key_node, main_scene)
+
+	Logger.log_generation("Maze+Keys door at %s with %d keys" % [str(door_cell), actual_keys])
+	context.set_player_spawn_override(MazeUtils.maze_cell_to_world(start_cell, maze_offset, cell_size))
+
+func _generate_maze_coins(grid: Array, start: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, main_scene) -> void:
+	var rows = grid.size()
+	var cols = grid[0].size()
+	var candidates: Array = []
+	for y in range(rows):
+		for x in range(cols):
+			if grid[y][x]:
+				continue
+			var cell = Vector2i(x, y)
+			if cell == start or cell == exit_cell:
+				continue
+			if (abs(cell.x - start.x) + abs(cell.y - start.y)) < 3:
+				continue
+			candidates.append(cell)
+	candidates.shuffle()
+	var desired = clamp(int(candidates.size() / 8.0), 5, 20)
+	for i in range(min(desired, candidates.size())):
+		var cell = candidates[i]
+		var world_pos = MazeUtils.maze_cell_to_world(cell, offset, cell_size)
+		var coin = LevelNodeFactory.create_coin_node(context.coins.size(), world_pos)
+		context.coins.append(coin)
+		context.add_generated_node(coin, main_scene)
+
+func _spawn_maze_walls(grid: Array, offset: Vector2, cell_size: float, main_scene) -> void:
+	var rows = grid.size()
+	var cols = grid[0].size()
+	for y in range(rows):
+		for x in range(cols):
+			if grid[y][x]:
+				var wall = LevelNodeFactory.create_maze_wall(context.maze_walls.size(), cell_size, WALL_COLOR, context.MAZE_WALL_SIZE_RATIO)
+				wall.position = offset + Vector2(x * cell_size, y * cell_size)
+				context.maze_walls.append(wall)
+				context.add_generated_node(wall, main_scene)

--- a/scripts/level_generators/MazeUtils.gd
+++ b/scripts/level_generators/MazeUtils.gd
@@ -1,0 +1,147 @@
+extends Object
+class_name MazeUtils
+
+static func init_maze_grid(cols: int, rows: int) -> Array:
+	var grid: Array = []
+	for y in range(rows):
+		var row := []
+		row.resize(cols)
+		for x in range(cols):
+			row[x] = true
+		grid.append(row)
+	return grid
+
+static func carve_maze(grid: Array, cell: Vector2i, cols: int, rows: int) -> void:
+	grid[cell.y][cell.x] = false
+	var directions = [Vector2i(2, 0), Vector2i(-2, 0), Vector2i(0, 2), Vector2i(0, -2)]
+	directions.shuffle()
+	for dir in directions:
+		var next = cell + dir
+		if next.x <= 0 or next.x >= cols - 1 or next.y <= 0 or next.y >= rows - 1:
+			continue
+		if grid[next.y][next.x]:
+			var between = cell + Vector2i(dir.x / 2, dir.y / 2)
+			grid[between.y][between.x] = false
+			carve_maze(grid, next, cols, rows)
+
+static func find_farthest_cell(grid: Array, start: Vector2i, cols: int, rows: int) -> Dictionary:
+	var visited: Array = []
+	for y in range(rows):
+		var row := []
+		row.resize(cols)
+		for x in range(cols):
+			row[x] = false
+		visited.append(row)
+	var queue: Array = []
+	queue.append({"cell": start, "dist": 0})
+	visited[start.y][start.x] = true
+	var farthest = start
+	var max_dist = 0
+	while not queue.is_empty():
+		var item = queue.pop_front()
+		var cell: Vector2i = item["cell"]
+		var dist: int = item["dist"]
+		if dist > max_dist:
+			max_dist = dist
+			farthest = cell
+		for dir in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
+			var next = cell + dir
+			if next.x < 0 or next.x >= cols or next.y < 0 or next.y >= rows:
+				continue
+			if grid[next.y][next.x] or visited[next.y][next.x]:
+				continue
+			visited[next.y][next.x] = true
+			queue.append({"cell": next, "dist": dist + 1})
+	return {"cell": farthest, "distance": max_dist}
+
+static func reconstruct_maze_path(grid: Array, start: Vector2i, goal: Vector2i, cols: int, rows: int) -> Array:
+	var visited: Dictionary = {}
+	var parents: Dictionary = {}
+	var queue: Array = []
+	queue.append(start)
+	visited[start] = true
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		if cell == goal:
+			break
+		for dir in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
+			var next = cell + dir
+			if next.x < 0 or next.x >= cols or next.y < 0 or next.y >= rows:
+				continue
+			if grid[next.y][next.x] or visited.has(next):
+				continue
+			visited[next] = true
+			parents[next] = cell
+			queue.append(next)
+	var path: Array = []
+	if not visited.has(goal):
+		path.append(start)
+		return path
+	var current = goal
+	while true:
+		path.push_front(current)
+		if current == start:
+			break
+		if not parents.has(current):
+			break
+		current = parents[current]
+	return path
+
+static func pick_maze_key_cells(grid: Array, path: Array, start_cell: Vector2i, door_cell: Vector2i, exit_cell: Vector2i, desired: int) -> Array:
+	var result: Array = []
+	if desired <= 0:
+		return result
+	var path_candidates: Array = []
+	for cell_variant in path:
+		var cell: Vector2i = cell_variant
+		if cell == start_cell or cell == door_cell or cell == exit_cell:
+			continue
+		if path_candidates.has(cell):
+			continue
+		path_candidates.append(cell)
+	path_candidates.shuffle()
+	for cell in path_candidates:
+		if result.size() >= desired:
+			break
+		result.append(cell)
+	if result.size() >= desired:
+		return result
+	var rows = grid.size()
+	if rows <= 0:
+		return result
+	var cols = grid[0].size() if rows > 0 else 0
+	var extras: Array = []
+	for y in range(rows):
+		for x in range(cols):
+			if grid[y][x]:
+				continue
+			var candidate = Vector2i(x, y)
+			if candidate == start_cell or candidate == door_cell or candidate == exit_cell:
+				continue
+			if result.has(candidate):
+				continue
+			extras.append(candidate)
+	extras.shuffle()
+	for cell in extras:
+		if result.size() >= desired:
+			break
+		result.append(cell)
+	return result
+
+static func maze_cell_to_world(cell: Vector2i, offset: Vector2, cell_size: float) -> Vector2:
+	return offset + Vector2(cell.x * cell_size + cell_size * 0.5, cell.y * cell_size + cell_size * 0.5)
+
+static func world_to_maze_cell(world: Vector2, offset: Vector2, cell_size: float) -> Vector2i:
+	var x = int(floor((world.x - offset.x) / cell_size))
+	var y = int(floor((world.y - offset.y) / cell_size))
+	return Vector2i(x, y)
+
+static func ensure_odd_cell(cell: Vector2i, cols: int, rows: int) -> Vector2i:
+	var result = cell
+	result.x = clamp(result.x, 1, cols - 2)
+	result.y = clamp(result.y, 1, rows - 2)
+	if result.x % 2 == 0:
+		result.x += 1 if (result.x + 1 < cols) else -1
+	if result.y % 2 == 0:
+		result.y += 1 if (result.y + 1 < rows) else -1
+	return result

--- a/scripts/level_generators/ObstacleUtilities.gd
+++ b/scripts/level_generators/ObstacleUtilities.gd
@@ -1,0 +1,66 @@
+extends RefCounted
+class_name ObstacleUtilities
+
+const LevelUtils = preload("res://scripts/LevelUtils.gd")
+
+var context
+
+func _init(level_context):
+	context = level_context
+
+func clear_in_rects(rects: Array) -> void:
+	if context.obstacles.is_empty():
+		return
+	var to_remove: Array = []
+	for obstacle in context.obstacles:
+		if not is_instance_valid(obstacle):
+			if not to_remove.has(obstacle):
+				to_remove.append(obstacle)
+			continue
+		var obstacle_rect = LevelUtils.get_obstacle_rect(obstacle)
+		for rect in rects:
+			if rect is Rect2 and obstacle_rect.intersects(rect):
+				if not to_remove.has(obstacle):
+					to_remove.append(obstacle)
+				break
+	_remove_obstacles(to_remove)
+
+func clear_near_points(points: Array, radius: float) -> void:
+	if context.obstacles.is_empty() or points.is_empty() or radius <= 0.0:
+		return
+	var radius_sq = radius * radius
+	var to_remove: Array = []
+	for obstacle in context.obstacles:
+		if not is_instance_valid(obstacle):
+			if not to_remove.has(obstacle):
+				to_remove.append(obstacle)
+			continue
+		for point in points:
+			if typeof(point) != TYPE_VECTOR2:
+				continue
+			if obstacle.position.distance_squared_to(point) <= radius_sq:
+				if not to_remove.has(obstacle):
+					to_remove.append(obstacle)
+				break
+	_remove_obstacles(to_remove)
+
+func clear_around_position(position: Vector2, radius: float) -> void:
+	if radius <= 0.0:
+		return
+	clear_near_points([position], radius)
+
+func _remove_obstacles(obstacles_to_remove: Array) -> void:
+	if obstacles_to_remove.is_empty():
+		return
+	var spawner_obstacles: Array = []
+	if context.obstacle_spawner and is_instance_valid(context.obstacle_spawner):
+		spawner_obstacles = context.obstacle_spawner.get_obstacles()
+	for obstacle in obstacles_to_remove:
+		if obstacle == null:
+			continue
+		if context.obstacles.has(obstacle):
+			context.obstacles.erase(obstacle)
+		if spawner_obstacles and spawner_obstacles.has(obstacle):
+			spawner_obstacles.erase(obstacle)
+		if is_instance_valid(obstacle):
+			obstacle.queue_free()


### PR DESCRIPTION
## Summary
- split the massive level generation logic into dedicated helpers for mazes, keys, and shared node factories
- extract obstacle cleanup, maze utilities, and coin placement helpers to remove duplication and keep scripts concise
- update the coin spawner to rely on the new utilities and shared node factory for consistent node creation

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dba7c7584c8323843de22d178633a1