### PR TITLE
Expand TimerManager unit coverage

### DIFF
--- a/tests/unit/test_timer_manager.gd
+++ b/tests/unit/test_timer_manager.gd
@@ -2,6 +2,7 @@ extends "res://tests/unit/test_utils.gd"
 
 const TimerManager = preload("res://scripts/TimerManager.gd")
 const LevelUtils = preload("res://scripts/LevelUtils.gd")
+const GameState = preload("res://scripts/GameState.gd")
 
 func get_suite_name() -> String:
 	return "TimerManager"
@@ -61,4 +62,71 @@ func test_calculate_level_time_accounts_for_coins() -> void:
 	var with_coin = tm.calculate_level_time(1, [coin], exit_pos)
 	assert_true(with_coin > without_coins)
 	coin.free()
+	tm.free()
+
+func test_set_difficulty_keeps_known_and_ignores_unknown() -> void:
+	var tm: TimerManager = _new_timer()
+	tm.set_difficulty("child")
+	var child_preset := TimerManager.DIFFICULTY_PRESETS["child"]
+	assert_eq(tm._get_preset(), child_preset)
+	tm.set_difficulty("impossible-mode")
+	assert_eq(tm._get_preset(), child_preset)
+	tm.free()
+
+func test_level_type_scale_interpolates_and_defaults() -> void:
+	var tm: TimerManager = _new_timer()
+	var start_scale := tm._level_type_scale(GameState.LevelType.MAZE, 1)
+	var end_scale := tm._level_type_scale(GameState.LevelType.MAZE, 9)
+	assert_true(start_scale > end_scale)
+	assert_near(end_scale, 1.42, 0.05)
+	var unknown_scale := tm._level_type_scale(9999, 3)
+	assert_near(unknown_scale, 1.0, 0.0001)
+	tm.free()
+
+func test_get_type_profile_returns_defaults_for_unknown() -> void:
+	var tm: TimerManager = _new_timer()
+	var profile := tm._get_type_profile(12345)
+	assert_eq(profile["scale_start"], 1.0)
+	assert_eq(profile["scale_end"], 1.0)
+	assert_eq(profile["buffer_bias"], 0.0)
+	assert_eq(profile["flat_bonus"], 0.0)
+	tm.free()
+
+func test_maze_overhead_handles_non_maze_types() -> void:
+	var tm: TimerManager = _new_timer()
+	var result := tm._maze_overhead(GameState.LevelType.KEYS, 0.0, Vector2.ZERO, Vector2.ZERO, 300.0)
+	assert_near(result["factor"], 1.0, 0.0001)
+	assert_near(result["slack"], 0.0, 0.0001)
+	assert_near(result["base_path"], 0.0, 0.0001)
+	tm.free()
+
+func test_maze_overhead_uses_path_statistics() -> void:
+	var tm: TimerManager = _new_timer()
+	var start := Vector2.ZERO
+	var exit := Vector2(100, 0)
+	var info := tm._maze_overhead(GameState.LevelType.MAZE, 300.0, start, exit, 300.0)
+	assert_true(info["factor"] > 1.0)
+	assert_true(info["slack"] > 0.0)
+	assert_near(info["base_path"], 300.0, 0.0001)
+	tm.free()
+
+func test_calculate_level_time_extends_minimum_for_pickups() -> void:
+	var tm: TimerManager = _new_timer()
+	var coin := Node2D.new()
+	coin.position = LevelUtils.PLAYER_START
+	var exit_pos := LevelUtils.PLAYER_START
+	var time := tm.calculate_level_time(1, [coin], exit_pos)
+	assert_true(time > float(tm._get_preset()["min_time"]))
+	coin.free()
+	tm.free()
+
+func test_get_time_for_level_reacts_to_surplus_history() -> void:
+	var tm: TimerManager = _new_timer()
+	var baseline := tm.get_time_for_level(3)
+	for i in range(TimerManager.SURPLUS_WINDOW):
+		tm.register_level_result(30.0)
+	var adjusted := tm.get_time_for_level(3)
+	var min_time := float(tm._get_preset()["min_time"])
+	assert_true(adjusted <= baseline)
+	assert_true(adjusted >= min_time)
 	tm.free()


### PR DESCRIPTION
## Summary
- add TimerManager test cases that validate difficulty selection, level type scaling, maze overhead, and surplus adjustment logic
- cover edge conditions for calculate_level_time minimum padding when pickups exist

## Testing
- tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68dbfe07bf388323bd0de75f39617125