### PR TITLE
Fix type resolution errors by preloading script classes in Main

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -5,6 +5,9 @@ const LevelController = preload("res://scripts/main/LevelController.gd")
 const UIController = preload("res://scripts/main/UIController.gd")
 const StatisticsLogger = preload("res://scripts/main/StatisticsLogger.gd")
 const GameFlowController = preload("res://scripts/main/GameFlowController.gd")
+const LevelGenerator = preload("res://scripts/LevelGenerator.gd")
+const TimerManager = preload("res://scripts/TimerManager.gd")
+const GameState = preload("res://scripts/GameState.gd")
 
 @onready var player: CharacterBody2D = $Player
 @onready var timer: Timer = $Timer


### PR DESCRIPTION
## Summary
- preload the LevelGenerator, TimerManager, and GameState scripts in Main.gd so their types are available at startup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc438eb5688323b7892b4aed0c53b6