### PR TITLE
Fix parser error by refactoring controller setup

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -46,10 +46,14 @@ var statistics_logger: StatisticsLogger = null
 var game_flow_controller: GameFlowController = null
 
 func _ready() -> void:
-	ui_controller = UIController.new(self, timer_label, coin_label, level_progress_label, game_over_label, win_label, restart_button, menu_button, key_container, key_status_container)
-	level_controller = LevelController.new(self, ui_controller)
-	statistics_logger = StatisticsLogger.new(self, timer_manager)
-	game_flow_controller = GameFlowController.new(self, ui_controller, level_controller, statistics_logger)
+	ui_controller = UIController.new()
+	ui_controller.setup(self, timer_label, coin_label, level_progress_label, game_over_label, win_label, restart_button, menu_button, key_container, key_status_container)
+	level_controller = LevelController.new()
+	level_controller.setup(self, ui_controller)
+	statistics_logger = StatisticsLogger.new()
+	statistics_logger.setup(self, timer_manager)
+	game_flow_controller = GameFlowController.new()
+	game_flow_controller.setup(self, ui_controller, level_controller, statistics_logger)
 	level_controller.set_game_flow_controller(game_flow_controller)
 	timer.timeout.connect(_on_timer_timeout)
 	restart_button.pressed.connect(_on_restart_pressed)

--- a/scripts/main/GameFlowController.gd
+++ b/scripts/main/GameFlowController.gd
@@ -8,7 +8,7 @@ var ui_controller: UIController = null
 var level_controller: LevelController = null
 var statistics_logger: StatisticsLogger = null
 
-func _init(
+func setup(
 	main_ref: Main,
 	ui_controller_ref: UIController,
 	level_controller_ref: LevelController,

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -8,7 +8,7 @@ var main: Main = null
 var ui_controller: UIController = null
 var game_flow_controller: GameFlowController = null
 
-func _init(main_ref: Main, ui_controller_ref: UIController) -> void:
+func setup(main_ref: Main, ui_controller_ref: UIController) -> void:
 	main = main_ref
 	ui_controller = ui_controller_ref
 

--- a/scripts/main/StatisticsLogger.gd
+++ b/scripts/main/StatisticsLogger.gd
@@ -7,7 +7,7 @@ var main: Main = null
 var timer_manager: TimerManager = null
 var statistics_file: FileAccess = null
 
-func _init(main_ref: Main, timer_manager_ref: TimerManager) -> void:
+func setup(main_ref: Main, timer_manager_ref: TimerManager) -> void:
 	main = main_ref
 	timer_manager = timer_manager_ref
 

--- a/scripts/main/UIController.gd
+++ b/scripts/main/UIController.gd
@@ -14,7 +14,7 @@ var key_status_container: Control = null
 var key_checkbox_nodes: Array[CheckBox] = []
 var key_colors: Array[Color] = []
 
-func _init(
+func setup(
 	main_ref: Main,
 	timer_label_ref: Label,
 	coin_label_ref: Label,


### PR DESCRIPTION
## Summary
- replace custom `_init` constructors in controller scripts with explicit `setup` methods
- update `Main.gd` to instantiate controllers without constructor arguments to resolve the `_init` parser error

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc443771508323bf01c4eef938700f