### PR TITLE
Refactor coin tracking to LevelController

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -30,12 +30,10 @@ var game_time: float = 30.0
 var total_coins: int = 0
 var collected_coins: int = 0
 var previous_coin_count: int = 0
-var keys: Array[Area2D] = []
 var total_keys: int = 0
 var collected_keys_count: int = 0
 var exit_active: bool = false
 var exit: Area2D = null
-var coins: Array[Area2D] = []
 var prevent_game_over: bool = false
 var level_start_time: float = 0.0
 var level_initializing: bool = false
@@ -51,7 +49,7 @@ func _ready() -> void:
 	level_controller = LevelController.new()
 	level_controller.setup(self, ui_controller)
 	statistics_logger = StatisticsLogger.new()
-	statistics_logger.setup(self, timer_manager)
+	statistics_logger.setup(self, timer_manager, level_controller)
 	game_flow_controller = GameFlowController.new()
 	game_flow_controller.setup(self, ui_controller, level_controller, statistics_logger)
 	level_controller.set_game_flow_controller(game_flow_controller)

--- a/scripts/main/StatisticsLogger.gd
+++ b/scripts/main/StatisticsLogger.gd
@@ -5,11 +5,13 @@ const Logger = preload("res://scripts/Logger.gd")
 
 var main: Main = null
 var timer_manager: TimerManager = null
+var level_controller: LevelController = null
 var statistics_file: FileAccess = null
 
-func setup(main_ref: Main, timer_manager_ref: TimerManager) -> void:
+func setup(main_ref: Main, timer_manager_ref: TimerManager, level_controller_ref: LevelController) -> void:
 	main = main_ref
 	timer_manager = timer_manager_ref
+	level_controller = level_controller_ref
 
 func init_logging() -> void:
 	var logs_dir: String = "logs"
@@ -33,7 +35,8 @@ func log_level_statistics() -> void:
 	var time_left: float = main.game_time
 	if main.player and main.exit:
 		distance = main.player.global_position.distance_to(main.exit.global_position)
-	var coin_total: int = main.coins.size()
+	var coins: Array[Area2D] = level_controller.get_active_coins() if level_controller else []
+	var coin_total: int = coins.size()
 	var completion_rate: float = 1.0 if coin_total == 0 else float(main.collected_coins) / float(max(coin_total, 1))
 	var stats_parts: Array[String] = [
 		str(main.game_state.current_level),


### PR DESCRIPTION
## Summary
- track generated coins and keys inside `LevelController` instead of on `Main`
- update `Main` and `StatisticsLogger` to use the controller for coin data
- expose active coins through a new getter for logging

## Testing
- ./tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68dc48ae85b08323a8a503fe830f1eaf