### PR TITLE
Adjust player speed boost defaults

### DIFF
--- a/config/game.cfg
+++ b/config/game.cfg
@@ -1,9 +1,9 @@
 ; Gameplay configuration for Mini 2D Game
 
 [gameplay]
-speed_boost_multiplier=1.05
-speed_boost_decay_time=2.4
-speed_boost_max_stacks=6
+speed_boost_multiplier=1.2
+speed_boost_decay_time=2.0
+speed_boost_max_stacks=5
 ghost_base_lifetime=0.25
 ghost_extra_lifetime=0.7
 ghost_spawn_interval=0.08

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -5,9 +5,9 @@ const CONFIG_PATH := "res://config/game.cfg"
 
 # Configurable speed boost settings
 @export var speed_boost_enabled := true
-@export var speed_boost_multiplier := 1.05
-@export var boost_decay_time := 2.4
-@export var max_boost_stacks := 6.0
+@export var speed_boost_multiplier := 1.2
+@export var boost_decay_time := 2.0
+@export var max_boost_stacks := 5.0
 @export var ghost_trail_enabled := true
 
 @onready var player_body: Control = $PlayerBody


### PR DESCRIPTION
## Summary
- raise the player speed boost multiplier to 1.2
- shorten the boost decay time to 2.0 seconds and cap stacks at 5 to match config

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcdcd33e648323ba526e2dd06989df