### PR TITLE
Fix indentation regressions and update speed boost defaults

### DIFF
--- a/config/game.cfg
+++ b/config/game.cfg
@@ -1,9 +1,9 @@
 ; Gameplay configuration for Mini 2D Game
 
 [gameplay]
-speed_boost_multiplier=1.05
-speed_boost_decay_time=2.4
-speed_boost_max_stacks=6
+speed_boost_multiplier=1.2
+speed_boost_decay_time=2.0
+speed_boost_max_stacks=5
 ghost_base_lifetime=0.25
 ghost_extra_lifetime=0.7
 ghost_spawn_interval=0.08

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -5,9 +5,9 @@ const CONFIG_PATH := "res://config/game.cfg"
 
 # Configurable speed boost settings
 @export var speed_boost_enabled := true
-@export var speed_boost_multiplier := 1.05
-@export var boost_decay_time := 2.4
-@export var max_boost_stacks := 6.0
+@export var speed_boost_multiplier := 1.2
+@export var boost_decay_time := 2.0
+@export var max_boost_stacks := 5.0
 @export var ghost_trail_enabled := true
 
 @onready var player_body: Control = $PlayerBody

--- a/scripts/TimerManager.gd
+++ b/scripts/TimerManager.gd
@@ -38,48 +38,48 @@ const LEVEL_TYPE_TUNING := {
 		"route_trim": 0.82,
 		"trim_ramp": 4.0
 	},
-GameState.LevelType.MAZE: {
-"scale_start": 1.05,
-"scale_end": 0.82,
-"buffer_bias": 0.12,
-"flat_bonus": 1.6,
-"maze_slack_curve": Vector2(3.5, 7.5),
-"maze_path_scale": 0.55,
-"maze_path_cap": 7.0,
-"maze_base_scale": 0.52,
-"maze_fallback_slack": 4.5,
-"maze_ratio_span": 2.0,
-"maze_path_floor": 1.05,
-"maze_fallback_factor": 1.18
-},
-GameState.LevelType.MAZE_COINS: {
-"scale_start": 1.08,
-"scale_end": 0.86,
-"buffer_bias": 0.18,
-"flat_bonus": 2.2,
-"maze_slack_curve": Vector2(4.0, 8.5),
-"maze_path_scale": 0.60,
-"maze_path_cap": 7.5,
-"maze_base_scale": 0.58,
-"maze_fallback_slack": 5.0,
-"maze_ratio_span": 2.2,
-"maze_path_floor": 1.08,
-"maze_fallback_factor": 1.22
-},
-GameState.LevelType.MAZE_KEYS: {
-"scale_start": 1.12,
-"scale_end": 0.90,
-"buffer_bias": 0.24,
-"flat_bonus": 2.8,
-"maze_slack_curve": Vector2(4.5, 9.5),
-"maze_path_scale": 0.65,
-"maze_path_cap": 8.0,
-"maze_base_scale": 0.62,
-"maze_fallback_slack": 5.5,
-"maze_ratio_span": 2.4,
-"maze_path_floor": 1.12,
-"maze_fallback_factor": 1.28
-},
+	GameState.LevelType.MAZE: {
+		"scale_start": 1.05,
+		"scale_end": 0.82,
+		"buffer_bias": 0.12,
+		"flat_bonus": 1.6,
+		"maze_slack_curve": Vector2(3.5, 7.5),
+		"maze_path_scale": 0.55,
+		"maze_path_cap": 7.0,
+		"maze_base_scale": 0.52,
+		"maze_fallback_slack": 4.5,
+		"maze_ratio_span": 2.0,
+		"maze_path_floor": 1.05,
+		"maze_fallback_factor": 1.18
+	},
+	GameState.LevelType.MAZE_COINS: {
+		"scale_start": 1.08,
+		"scale_end": 0.86,
+		"buffer_bias": 0.18,
+		"flat_bonus": 2.2,
+		"maze_slack_curve": Vector2(4.0, 8.5),
+		"maze_path_scale": 0.60,
+		"maze_path_cap": 7.5,
+		"maze_base_scale": 0.58,
+		"maze_fallback_slack": 5.0,
+		"maze_ratio_span": 2.2,
+		"maze_path_floor": 1.08,
+		"maze_fallback_factor": 1.22
+	},
+	GameState.LevelType.MAZE_KEYS: {
+		"scale_start": 1.12,
+		"scale_end": 0.90,
+		"buffer_bias": 0.24,
+		"flat_bonus": 2.8,
+		"maze_slack_curve": Vector2(4.5, 9.5),
+		"maze_path_scale": 0.65,
+		"maze_path_cap": 8.0,
+		"maze_base_scale": 0.62,
+		"maze_fallback_slack": 5.5,
+		"maze_ratio_span": 2.4,
+		"maze_path_floor": 1.12,
+		"maze_fallback_factor": 1.28
+	},
 	GameState.LevelType.KEYS: {
 		"scale_start": 1.08,
 		"scale_end": 0.96,
@@ -87,7 +87,6 @@ GameState.LevelType.MAZE_KEYS: {
 		"flat_bonus": 0.6
 	}
 }
-
 
 const BASE_TIME_PER_LEVEL := 22.0
 var _difficulty: StringName = &"regular"
@@ -143,7 +142,6 @@ func register_level_result(time_left_sec: float) -> void:
 	_recent_surplus.append(max(time_left_sec, 0.0))
 	if _recent_surplus.size() > SURPLUS_WINDOW:
 		_recent_surplus.pop_front()
-
 
 func calculate_level_time(level: int, coins: Array, exit_pos: Vector2, player_start: Vector2 = LevelUtils.PLAYER_START, level_type: int = GameState.LevelType.OBSTACLES_COINS, maze_path_length: float = 0.0) -> float:
 	var p := _get_preset()

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -132,7 +132,6 @@ func generate(main_scene, level: int, player_start_position: Vector2) -> void:
 
 	context.set_player_spawn_override(spawn_override)
 
-
 func _generate_key_level_obstacles(level_size: float, main_scene, level: int, offset: Vector2, level_width: float, level_height: float, door_layouts: Array, spawn_override: Vector2) -> void:
 	if context.obstacle_spawner == null or not is_instance_valid(context.obstacle_spawner):
 		Logger.log_error("ObstacleSpawner unavailable for key level")

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -22,34 +22,38 @@ func generate_new_level() -> void:
 	if main.game_state.current_level > 7:
 		main.game_state.reset_to_start()
 		Logger.log_game_mode("Level exceeded cap, reset to level", [main.game_state.current_level])
-Logger.log_generation("Generating level %d (size: %.2f)" % [main.game_state.current_level, generation_level_size])
-main.level_start_time = Time.get_ticks_msec() / 1000.0
-main.collected_coins = main.previous_coin_count
-main.exit_active = false
-main.exit = null
-coins = [] as Array[Area2D]
-keys = [] as Array[Area2D]
-main.game_state.set_state(GameState.GameStateType.PLAYING)
-if main.game_state.current_state != GameState.GameStateType.PLAYING:
-Logger.log_game_mode("Game state corrected to PLAYING before generation")
-main.game_state.set_state(GameState.GameStateType.PLAYING)
-if game_flow_controller:
-game_flow_controller.handle_timer_for_game_state()
-await main.get_tree().process_frame
-var level_type: int = main.game_state.get_current_level_type()
-var generation_level_size: float = main.game_state.current_level_size
-if level_type == GameState.LevelType.KEYS:
-generation_level_size = min(generation_level_size + 0.35, main.game_state.max_level_size + 0.25)
-LevelUtils.update_level_boundaries(generation_level_size, main.play_area, main.boundaries)
-position_player_within_level(generation_level_size)
-var level_type_names: Array[String] = ["Obstacles+Coins", "Keys", "Maze", "Maze+Coins", "Maze+Keys", "Random", "Challenge"]
-var level_type_label: String = level_type_names[level_type] if level_type < level_type_names.size() else str(level_type)
-Logger.log_game_mode("Preparing level type: %s" % level_type_label)
-var generate_obstacles: bool = true
-var generate_coins: bool = true
-if main.level_generator and is_instance_valid(main.level_generator):
-generate_obstacles = main.game_state.generate_obstacles
-generate_coins = main.game_state.generate_coins
+
+	var generation_level_size: float = main.game_state.current_level_size
+	Logger.log_generation("Generating level %d (size: %.2f)" % [main.game_state.current_level, generation_level_size])
+	main.level_start_time = Time.get_ticks_msec() / 1000.0
+	main.collected_coins = main.previous_coin_count
+	main.exit_active = false
+	main.exit = null
+	coins = [] as Array[Area2D]
+	keys = [] as Array[Area2D]
+	main.game_state.set_state(GameState.GameStateType.PLAYING)
+	if main.game_state.current_state != GameState.GameStateType.PLAYING:
+		Logger.log_game_mode("Game state corrected to PLAYING before generation")
+		main.game_state.set_state(GameState.GameStateType.PLAYING)
+	if game_flow_controller:
+		game_flow_controller.handle_timer_for_game_state()
+	await main.get_tree().process_frame
+
+	var level_type: int = main.game_state.get_current_level_type()
+	if level_type == GameState.LevelType.KEYS:
+		generation_level_size = min(generation_level_size + 0.35, main.game_state.max_level_size + 0.25)
+	LevelUtils.update_level_boundaries(generation_level_size, main.play_area, main.boundaries)
+	position_player_within_level(generation_level_size)
+
+	var level_type_names: Array[String] = ["Obstacles+Coins", "Keys", "Maze", "Maze+Coins", "Maze+Keys", "Random", "Challenge"]
+	var level_type_label: String = level_type_names[level_type] if level_type < level_type_names.size() else str(level_type)
+	Logger.log_game_mode("Preparing level type: %s" % level_type_label)
+
+	var generate_obstacles: bool = true
+	var generate_coins: bool = true
+	if main.level_generator and is_instance_valid(main.level_generator):
+		generate_obstacles = main.game_state.generate_obstacles
+		generate_coins = main.game_state.generate_coins
 		if level_type == GameState.LevelType.KEYS:
 			generate_obstacles = false
 			generate_coins = false
@@ -60,18 +64,20 @@ generate_coins = main.game_state.generate_coins
 		if level_type == GameState.LevelType.MAZE or level_type == GameState.LevelType.MAZE_COINS or level_type == GameState.LevelType.MAZE_KEYS:
 			generate_obstacles = false
 			generate_coins = false
-main.level_generator.generate_level(
-generation_level_size,
-generate_obstacles,
-generate_coins,
-main.game_state.min_exit_distance_ratio,
-main.game_state.use_full_map_coverage,
-main,
+
+	main.level_generator.generate_level(
+		generation_level_size,
+		generate_obstacles,
+		generate_coins,
+		main.game_state.min_exit_distance_ratio,
+		main.game_state.use_full_map_coverage,
+		main,
 		main.game_state.current_level,
 		main.previous_coin_count,
 		main.player.global_position if main.player else LevelUtils.PLAYER_START,
 		level_type
 	)
+
 	main.exit = main.level_generator.get_generated_exit()
 	coins = main.level_generator.get_generated_coins() as Array[Area2D]
 	keys = main.level_generator.get_generated_keys() as Array[Area2D]
@@ -97,6 +103,7 @@ main,
 		)
 	else:
 		main.game_time = 30.0
+
 	for coin in coins:
 		var coin_area: Area2D = coin
 		if coin_area and is_instance_valid(coin_area):
@@ -107,10 +114,12 @@ main,
 	main.collected_coins = 0
 	if main.total_coins == 0:
 		main.previous_coin_count = 0
+
 	if main.exit and is_instance_valid(main.exit):
 		var exit_callable: Callable = Callable(main, "_on_exit_entered")
 		if not main.exit.body_entered.is_connected(exit_callable):
 			main.exit.body_entered.connect(exit_callable)
+
 	main.collected_keys_count = 0
 	main.total_keys = keys.size()
 	for key in keys:
@@ -119,6 +128,7 @@ main,
 			var key_callable: Callable = Callable(main, "_on_key_collected")
 			if not key_node.is_connected("key_collected", key_callable):
 				key_node.connect("key_collected", key_callable)
+
 	main.timer.wait_time = main.game_time
 	main.timer.stop()
 	main.timer.start()
@@ -138,10 +148,10 @@ main,
 	main.level_initializing = false
 
 func position_player_within_level(level_size: float = -1.0) -> void:
-var size_to_use: float = level_size
-if size_to_use <= 0.0:
-size_to_use = main.game_state.current_level_size
-var dimensions: Dictionary = LevelUtils.get_scaled_level_dimensions(size_to_use)
+	var size_to_use: float = level_size
+	if size_to_use <= 0.0:
+		size_to_use = main.game_state.current_level_size
+	var dimensions: Dictionary = LevelUtils.get_scaled_level_dimensions(size_to_use)
 	var level_width: float = dimensions.width
 	var level_height: float = dimensions.height
 	var offset_x: float = dimensions.offset_x


### PR DESCRIPTION
## Summary
- restore indentation across player movement, timer manager, and level generation scripts
- update the speed boost defaults to 1.2/2.0/5.0 and sync the runtime config values
- keep timer manager tuning dictionaries structured while preserving the intended tuning values

## Testing
- ./tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68dcdcd9a7b483238a34e706e6111a81