### PR TITLE
Refactor maze generation helpers and update tests

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -157,6 +157,26 @@ text = "Coins: 0/5"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="DoorContainer" type="HBoxContainer" parent="UI"]
+visible = false
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = -240.0
+offset_right = 260.0
+offset_bottom = -200.0
+
+[node name="DoorLabel" type="Label" parent="UI/DoorContainer"]
+layout_mode = 2
+text = "Doors:"
+vertical_alignment = 1
+
+[node name="DoorStatus" type="HBoxContainer" parent="UI/DoorContainer"]
+custom_minimum_size = Vector2(140, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+
 [node name="KeyContainer" type="HBoxContainer" parent="UI"]
 visible = false
 anchors_preset = 2

--- a/scripts/Door.gd
+++ b/scripts/Door.gd
@@ -1,5 +1,7 @@
 extends StaticBody2D
 
+signal door_opened(door_id: int, door_color: Color)
+
 @export var door_id: int = 0
 @export var required_keys: int = 1
 @export var initially_open: bool = false
@@ -41,6 +43,7 @@ func _open_door() -> void:
 	_set_collision_disabled(true)
 	_apply_body_color(_open_color)
 	z_index = -5
+	_emit_door_opened()
 
 func _apply_closed_state() -> void:
 	_is_open = false
@@ -68,3 +71,12 @@ func _compute_open_color(color: Color) -> Color:
 func _apply_body_color(color: Color) -> void:
 	if body:
 		body.color = color
+
+func is_open() -> bool:
+	return _is_open
+
+func get_door_color() -> Color:
+	return _door_color
+
+func _emit_door_opened() -> void:
+	emit_signal("door_opened", door_id, _door_color)

--- a/scripts/LevelGenerator.gd
+++ b/scripts/LevelGenerator.gd
@@ -115,6 +115,9 @@ func get_generated_coins():
 func get_generated_keys():
 	return key_items
 
+func get_generated_doors():
+	return doors
+
 func get_generated_exit():
 	if exit_spawner:
 		return exit_spawner.get_exit()

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -21,6 +21,8 @@ const GAME_STATE := preload("res://scripts/GameState.gd")
 @onready var menu_button: Button = $UI/MenuButton
 @onready var key_container: Control = $UI/KeyContainer
 @onready var key_status_container: Control = $UI/KeyContainer/KeyStatus
+@onready var door_container: Control = $UI/DoorContainer
+@onready var door_status_container: Control = $UI/DoorContainer/DoorStatus
 @onready var level_generator: LEVEL_GENERATOR = $LevelGenerator
 @onready var timer_manager: TIMER_MANAGER = $TimerManager
 @onready var play_area: ColorRect = $PlayArea
@@ -47,7 +49,21 @@ var game_flow_controller: GAME_FLOW_CONTROLLER = null
 
 func _ready() -> void:
 	ui_controller = UI_CONTROLLER.new()
-	ui_controller.setup(self, timer_label, coin_label, level_progress_label, game_over_label, win_label, restart_button, menu_button, key_container, key_status_container, speed_label)
+	ui_controller.setup(
+		self,
+		timer_label,
+		coin_label,
+		level_progress_label,
+		game_over_label,
+		win_label,
+		restart_button,
+		menu_button,
+		key_container,
+		key_status_container,
+		door_container,
+		door_status_container,
+		speed_label
+	)
 	level_controller = LEVEL_CONTROLLER.new()
 	level_controller.setup(self, ui_controller)
 	statistics_logger = STATISTICS_LOGGER.new()
@@ -74,16 +90,16 @@ func _process(delta: float) -> void:
 		return
 	game_time -= delta
 	ui_controller.update_timer_display(game_time)
-	
+
 	# Update tug of war force
 	if game_state.has_method("update_tug_of_war_force"):
 		game_state.update_tug_of_war_force(delta)
-	
+
 	# Update speed display
 	if player and is_instance_valid(player):
 		var boost_count = player.get_boost_count()
 		ui_controller.update_speed_display(player.current_speed, boost_count)
-	
+
 	if game_time <= 0.0:
 		game_flow_controller.trigger_game_over()
 
@@ -92,6 +108,9 @@ func _on_coin_collected(body: Node, coin: Area2D) -> void:
 
 func _on_key_collected(door_id: int) -> void:
 	level_controller.handle_key_collected(door_id)
+
+func _on_door_opened(door_id: int, door_color: Color) -> void:
+	level_controller.handle_door_opened(door_id, door_color)
 
 func _on_timer_timeout() -> void:
 	game_flow_controller.on_timer_timeout()

--- a/scripts/fog/FogRaycaster.gd
+++ b/scripts/fog/FogRaycaster.gd
@@ -1,0 +1,60 @@
+class_name FogRaycaster
+extends RefCounted
+
+const MIN_RAY_COUNT := 32
+const ANGLE_JITTER := 0.0006
+const MIN_ANGLE_DELTA := 0.0001
+
+static func build_angles(ray_count: int) -> PackedFloat32Array:
+	var clamped: int = max(ray_count, MIN_RAY_COUNT)
+	var step: float = TAU / float(clamped)
+	var angles := PackedFloat32Array()
+	for i in range(clamped):
+		var base := step * float(i)
+		angles.push_back(_wrap_angle(base))
+		angles.push_back(_wrap_angle(base + ANGLE_JITTER))
+		angles.push_back(_wrap_angle(base - ANGLE_JITTER))
+	return angles
+
+static func cast_rays(space_state: PhysicsDirectSpaceState2D, origin: Vector2, radius: float, angles: PackedFloat32Array, excluded: Array[RID]) -> Array:
+	var results: Array = []
+	for angle in angles:
+		var direction := Vector2.RIGHT.rotated(angle)
+		var target := origin + direction * radius
+		var params := PhysicsRayQueryParameters2D.create(origin, target)
+		params.exclude = excluded
+		params.collide_with_bodies = true
+		params.collide_with_areas = false
+		var hit: Dictionary = space_state.intersect_ray(params)
+		var hit_point: Vector2 = hit.get("position", target)
+		results.append([angle, hit_point])
+	if results.size() > 1:
+		results.sort_custom(Callable(FogRaycaster, "_sort_hits"))
+	return results
+
+static func build_polygon(hit_results: Array, origin: Vector2, fallback: PackedVector2Array, use_fallback: bool) -> PackedVector2Array:
+	var polygon := PackedVector2Array()
+	var last_angle := -1.0
+	for entry in hit_results:
+		var angle := float(entry[0])
+		if last_angle >= 0.0 and abs(angle - last_angle) < MIN_ANGLE_DELTA:
+			continue
+		last_angle = angle
+		var point: Vector2 = entry[1]
+		polygon.push_back(point - origin)
+	if polygon.size() < 3:
+		return fallback if use_fallback else PackedVector2Array()
+	return polygon
+
+static func create_fallback_circle(radius: float, segments: int = 48) -> PackedVector2Array:
+	var fallback := PackedVector2Array()
+	for i in range(segments):
+		var angle := TAU * float(i) / float(segments)
+		fallback.push_back(Vector2.RIGHT.rotated(angle) * radius)
+	return fallback
+
+static func _wrap_angle(angle: float) -> float:
+	return fposmod(angle, TAU)
+
+static func _sort_hits(a, b) -> bool:
+	return float(a[0]) < float(b[0])

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -5,6 +5,7 @@ class_name KeyLevelGenerator
 const LOGGER := preload("res://scripts/Logger.gd")
 const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
 const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+const KEY_DOOR_PLANNER := preload("res://scripts/level_generators/key/KeyDoorPlanner.gd")
 
 const BARRIER_COLOR := Color(0.18, 0.21, 0.32, 1)
 const DOOR_EDGE_MARGIN := 45.0
@@ -12,10 +13,12 @@ const MIN_DOOR_GAP := 140.0
 
 var context
 var obstacle_utils
+var _door_planner
 
 func _init(level_context, obstacle_helper):
 	context = level_context
 	obstacle_utils = obstacle_helper
+	_door_planner = KEY_DOOR_PLANNER.new(context)
 
 func generate(main_scene, level: int, player_start_position: Vector2) -> void:
 	var dims = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
@@ -171,140 +174,19 @@ func _generate_key_level_obstacles(level_size: float, main_scene, level: int, of
 		obstacle_utils.clear_around_position(spawn_override, 140.0)
 
 func _sample_far_points(count: int, offset: Vector2, level_width: float, level_height: float, min_distance: float) -> Array:
-	var points: Array = []
-	var attempts: int = 0
-	var spacing: float = min_distance
-	while points.size() < count and attempts < 400:
-		var candidate = Vector2(
-			randf_range(offset.x + 120.0, offset.x + level_width - 120.0),
-			randf_range(offset.y + 120.0, offset.y + level_height - 120.0)
-		)
-		var valid := true
-		for existing in points:
-			if existing.distance_to(candidate) < spacing:
-				valid = false
-				break
-		if valid:
-			points.append(candidate)
-		else:
-			attempts += 1
-			if attempts % 80 == 0 and spacing > 140.0:
-				spacing *= 0.85
-	if points.size() < count:
-		for i in range(count - points.size()):
-			var t = float(points.size() + i + 1) / float(count + 1)
-			var fallback = Vector2(
-				offset.x + level_width * t,
-				offset.y + level_height * randf_range(0.25, 0.75)
-			)
-			points.append(fallback)
-	return points
+	return _door_planner.sample_far_points(count, offset, level_width, level_height, min_distance)
+
 func _enforce_door_spacing(door_layouts: Array, offset: Vector2, level_width: float, min_gap: float) -> void:
-	if door_layouts.size() <= 1:
-		return
-	var sorted := door_layouts.duplicate()
-	sorted.sort_custom(func(a, b):
-		return float(a.get("center_x", 0.0)) < float(b.get("center_x", 0.0)))
-	var left_bound := offset.x + DOOR_EDGE_MARGIN
-	var right_bound := offset.x + level_width - DOOR_EDGE_MARGIN
-	var widths: Array[float] = []
-	var total_width := 0.0
-	for layout in sorted:
-		var width := float(layout.get("door_width", 48.0))
-		widths.append(width)
-		total_width += width
-	var desired_gap: float = min_gap
-	var separators: int = max(sorted.size() - 1, 0)
-	if separators > 0:
-		var available_span: float = max(right_bound - left_bound, 0.0)
-		var required_span: float = total_width + desired_gap * float(separators)
-		if required_span > available_span and available_span > total_width:
-			desired_gap = max(min_gap * 0.6, (available_span - total_width) / float(separators))
-			LOGGER.log_generation("Compressed door spacing from %.1f to %.1f to fit width" % [min_gap, desired_gap])
-	var total_spacing: float = desired_gap * float(separators)
-	var available_width: float = max(right_bound - left_bound, 0.0)
-	var start_offset: float = 0.0
-	if available_width > (total_width + total_spacing):
-		start_offset = (available_width - (total_width + total_spacing)) * 0.5
-	var cursor: float = left_bound + start_offset
-	for i in range(sorted.size()):
-		var layout: Dictionary = sorted[i]
-		var width: float = widths[i]
-		var half: float = width * 0.5
-		cursor = max(cursor, left_bound)
-		var center: float = clamp(cursor + half, left_bound + half, right_bound - half)
-		layout["center_x"] = center
-		cursor = center + half + desired_gap
-	for layout in sorted:
-		var original_index := int(layout.get("index", -1))
-		if original_index >= 0 and original_index < door_layouts.size():
-			var target: Dictionary = door_layouts[original_index]
-			target["center_x"] = layout["center_x"]
-			door_layouts[original_index] = target
+	_door_planner.enforce_spacing(door_layouts, offset, level_width, min_gap, DOOR_EDGE_MARGIN)
 
 func _pick_keys_for_door(
 	door_center: Vector2,
 	keys_needed: int,
 	offset: Vector2,
-	_level_width: float,
+	level_width: float,
 	level_height: float,
 	spawn_override: Vector2,
 	exit_position: Vector2,
 	used_positions: Array
 ) -> Array:
-	var result: Array = []
-	if keys_needed <= 0:
-		return result
-	var min_spacing: float = 150.0
-	var attempts: int = 0
-	
-	# Ensure keys are placed in the accessible area (left side of door from player perspective)
-	var accessible_x_max = door_center.x - 50.0 # Leave space before the door
-	var accessible_x_min = offset.x + 90.0
-	
-	while result.size() < keys_needed and attempts < 240:
-		var candidate = Vector2(
-			randf_range(accessible_x_min, accessible_x_max),
-			randf_range(offset.y + 90.0, offset.y + level_height - 90.0)
-		)
-		
-		# Check if key is in accessible area (before the door)
-		if candidate.x >= door_center.x - 30.0:
-			attempts += 1
-			continue
-		
-		# Check for collision with obstacles
-		var collides_with_obstacle = false
-		for obstacle in context.obstacles:
-			if obstacle and is_instance_valid(obstacle):
-				var obstacle_rect = LEVEL_UTILS.get_obstacle_rect(obstacle)
-				if obstacle_rect.has_point(candidate):
-					collides_with_obstacle = true
-					break
-		
-		if collides_with_obstacle:
-			attempts += 1
-			continue
-			
-		var score = min(candidate.distance_to(door_center), candidate.distance_to(spawn_override))
-		score = min(score, candidate.distance_to(exit_position))
-		for used in used_positions:
-			score = min(score, candidate.distance_to(used))
-		for existing in result:
-			score = min(score, candidate.distance_to(existing))
-		if score < min_spacing:
-			attempts += 1
-			if attempts % 60 == 0 and min_spacing > 90.0:
-				min_spacing *= 0.9
-			continue
-		result.append(candidate)
-		used_positions.append(candidate)
-	if result.size() < keys_needed:
-		while result.size() < keys_needed:
-			var fallback = Vector2(
-				randf_range(accessible_x_min, accessible_x_max),
-				offset.y + level_height * randf_range(0.25, 0.75)
-			)
-			result.append(fallback)
-			used_positions.append(fallback)
-	return result
+	return _door_planner.pick_keys_for_door(door_center, keys_needed, offset, level_width, level_height, spawn_override, exit_position, used_positions)

--- a/scripts/level_generators/MazeGenerator.gd
+++ b/scripts/level_generators/MazeGenerator.gd
@@ -2,79 +2,40 @@ extends Object
 class_name MazeGenerator
 
 const LOGGER := preload("res://scripts/Logger.gd")
-const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
 const MAZE_UTILS := preload("res://scripts/level_generators/MazeUtils.gd")
 const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
-const MAZE_REACHABILITY_JOB: GDScript = preload("res://scripts/level_generators/MazeReachabilityJob.gd")
 
-const WALL_COLOR := Color(0.15, 0.18, 0.28, 1)
 const PLAYER_COLLISION_SIZE := 32.0
 const BLACK_SHADOW_COLOR := Color(0.0, 0.0, 0.0, 1.0)
-const DEBUG_LOG_DIR := "user://logs"
-const DEBUG_LOG_FILE := "maze_debug.log"
+
+const MAZE_LAYOUT_BUILDER := preload("res://scripts/level_generators/maze/MazeLayoutBuilder.gd")
+const MAZE_DOOR_PLANNER := preload("res://scripts/level_generators/maze/MazeDoorAndKeyPlanner.gd")
+const MAZE_COIN_DISTRIBUTOR := preload("res://scripts/level_generators/maze/MazeCoinDistributor.gd")
+const MAZE_DEBUG_LOGGER := preload("res://scripts/level_generators/maze/MazeDebugLogger.gd")
 
 var context
-var _debug_logging := false
-var _debug_file: FileAccess = null
+var _layout_builder
+var _door_planner
+var _coin_distributor
+var _debug_logger
 
 func _init(level_context, _obstacle_helper):
 	context = level_context
-
-func _setup_debug_logging() -> void:
-	_debug_logging = true
-	if Engine.has_meta("maze_debug_logging"):
-		_debug_logging = bool(Engine.get_meta("maze_debug_logging"))
-		if _debug_logging:
-			_open_debug_file()
-
-func _open_debug_file() -> void:
-	if _debug_file:
-		return
-	DirAccess.make_dir_recursive_absolute(DEBUG_LOG_DIR)
-	var path := "%s/%s" % [DEBUG_LOG_DIR, DEBUG_LOG_FILE]
-	_debug_file = FileAccess.open(path, FileAccess.WRITE)
-	if _debug_file:
-		_debug_file.store_line("MazeGenerator debug log started")
-		_debug_file.flush()
-
-func _log_debug(message: String) -> void:
-	if not _debug_logging:
-		return
-	if _debug_file == null:
-		_open_debug_file()
-	if _debug_file:
-		_debug_file.store_line(message)
-		_debug_file.flush()
+	_layout_builder = MAZE_LAYOUT_BUILDER.new(context)
+	_door_planner = MAZE_DOOR_PLANNER.new()
+	_coin_distributor = MAZE_COIN_DISTRIBUTOR.new(context)
+	_debug_logger = MAZE_DEBUG_LOGGER.new()
 
 func generate_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
-	_setup_debug_logging()
-	var dims = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
-	var level_width: float = float(dims.width)
-	var level_height: float = float(dims.height)
-	var offset = Vector2(dims.offset_x, dims.offset_y)
-
-	var cell_size = context.MAZE_BASE_CELL_SIZE
-	var cols = int(floor(level_width / cell_size))
-	var rows = int(floor(level_height / cell_size))
-	cols = max(cols | 1, 5)
-	rows = max(rows | 1, 5)
-	var maze_width = cols * cell_size
-	var maze_height = rows * cell_size
-	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
-
-	var start_cell: Vector2i
-	# For larger levels (1.2+), place player in random spot
-	if context.current_level_size >= 1.2:
-		start_cell = _get_random_maze_cell(cols, rows)
-	else:
-		start_cell = MAZE_UTILS.world_to_maze_cell(player_start_position, maze_offset, cell_size)
-		start_cell = MAZE_UTILS.ensure_odd_cell(start_cell, cols, rows)
-
-	var grid = MAZE_UTILS.init_maze_grid(cols, rows)
-	MAZE_UTILS.carve_maze(grid, start_cell, cols, rows)
-	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
-	_fill_unreachable_areas(grid, start_cell, maze_offset, cell_size, main_scene)
-
+	var layout := _build_layout(main_scene, player_start_position)
+	if layout.is_empty():
+		return
+	var grid: Array = layout.get("grid", [])
+	var cols: int = layout.get("cols", 0)
+	var rows: int = layout.get("rows", 0)
+	var cell_size: float = layout.get("cell_size", 0.0)
+	var maze_offset: Vector2 = layout.get("maze_offset", Vector2.ZERO)
+	var start_cell: Vector2i = layout.get("start_cell", Vector2i.ZERO)
 	var farthest_data = MAZE_UTILS.find_farthest_cell(grid, start_cell, cols, rows)
 	var farthest: Vector2i = farthest_data["cell"]
 	var path_steps: int = farthest_data["distance"]
@@ -85,64 +46,39 @@ func generate_maze_level(include_coins: bool, main_scene, player_start_position:
 	var exit_node = context.exit_spawner.get_exit()
 	if exit_node:
 		context.exit_pos = exit_node.position
-
-	context.set_player_spawn_override(MAZE_UTILS.maze_cell_to_world(start_cell, maze_offset, cell_size))
-
 	context.coins.clear()
 	if include_coins:
-		_generate_maze_coins(grid, start_cell, farthest, maze_offset, cell_size, main_scene)
+		_coin_distributor.populate(grid, start_cell, farthest, maze_offset, cell_size, main_scene)
 
 func generate_maze_keys_level(main_scene, level: int, player_start_position: Vector2) -> void:
-	_setup_debug_logging()
-	var dims = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
-	var level_width: float = float(dims.width)
-	var level_height: float = float(dims.height)
-	var offset = Vector2(dims.offset_x, dims.offset_y)
-
-	var cell_size = context.MAZE_BASE_CELL_SIZE
-	var cols = int(floor(level_width / cell_size))
-	var rows = int(floor(level_height / cell_size))
-	cols = max(cols | 1, 5)
-	rows = max(rows | 1, 5)
-	var maze_width = cols * cell_size
-	var maze_height = rows * cell_size
-	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
-
-	var start_cell: Vector2i
-	# For larger levels (1.2+), place player in random spot
-	if context.current_level_size >= 1.2:
-		start_cell = _get_random_maze_cell(cols, rows)
-	else:
-		start_cell = MAZE_UTILS.world_to_maze_cell(player_start_position, maze_offset, cell_size)
-		start_cell = MAZE_UTILS.ensure_odd_cell(start_cell, cols, rows)
-
-	var grid = MAZE_UTILS.init_maze_grid(cols, rows)
-	MAZE_UTILS.carve_maze(grid, start_cell, cols, rows)
-	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
-	_fill_unreachable_areas(grid, start_cell, maze_offset, cell_size, main_scene)
-
+	var layout := _build_layout(main_scene, player_start_position)
+	if layout.is_empty():
+		return
+	var grid: Array = layout.get("grid", [])
+	var cols: int = layout.get("cols", 0)
+	var rows: int = layout.get("rows", 0)
+	var cell_size: float = layout.get("cell_size", 0.0)
+	var maze_offset: Vector2 = layout.get("maze_offset", Vector2.ZERO)
+	var start_cell: Vector2i = layout.get("start_cell", Vector2i.ZERO)
+	var start_world: Vector2 = layout.get("start_world", Vector2.ZERO)
 	var farthest_data = MAZE_UTILS.find_farthest_cell(grid, start_cell, cols, rows)
 	var exit_cell: Vector2i = farthest_data["cell"]
 	var path_steps: int = farthest_data["distance"]
 	context.last_maze_path_length = float(max(path_steps, 1)) * cell_size
-
 	var path: Array = MAZE_UTILS.reconstruct_maze_path(grid, start_cell, exit_cell, cols, rows)
 	var path_index := {}
 	for i in range(path.size()):
 		var path_cell: Vector2i = path[i]
 		path_index[path_cell] = i
-
 	context.coins.clear()
 	context.exit_spawner.clear_exit()
-
 	var exit_position = MAZE_UTILS.maze_cell_to_world(exit_cell, maze_offset, cell_size)
 	context.exit_spawner.create_exit_at(exit_position, main_scene)
 	var exit_node = context.exit_spawner.get_exit()
 	if exit_node:
 		context.exit_pos = exit_node.position
-
 	var desired_door_count = clamp(2 + int(floor(level / 3.0)), 2, 5)
-	var door_cells: Array = _select_maze_door_cells(path, start_cell, exit_cell, maze_offset, cell_size, desired_door_count)
+	var door_cells: Array = _door_planner.select_door_cells(path, start_cell, exit_cell, maze_offset, cell_size, desired_door_count)
 	if door_cells.is_empty():
 		door_cells.append(exit_cell)
 	else:
@@ -150,7 +86,6 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 			var ia: int = int(path_index.get(a, 0))
 			var ib: int = int(path_index.get(b, 0))
 			return ia < ib)
-	var start_world = MAZE_UTILS.maze_cell_to_world(start_cell, maze_offset, cell_size)
 	var exit_world = MAZE_UTILS.maze_cell_to_world(exit_cell, maze_offset, cell_size)
 	var door_worlds: Array[Vector2] = []
 	for door_cell in door_cells:
@@ -163,9 +98,9 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 		var blocked: Array = []
 		for j in range(i, door_cells.size()):
 			blocked.append(door_cells[j])
-		var reachable_cells: Array = _collect_reachable_cells_before_door(grid, start_cell, blocked)
+		var reachable_cells: Array = _door_planner.collect_reachable_cells_before_door(grid, start_cell, blocked)
 		var keys_target = clamp(1 + int(floor(level / 4.0)) + (i % 2), 1, 4)
-		var key_cells: Array = _select_maze_key_cells(
+		var key_cells: Array = _door_planner.select_key_cells(
 			reachable_cells,
 			keys_target,
 			maze_offset,
@@ -181,7 +116,7 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 		)
 		if key_cells.is_empty() and keys_target > 0:
 			var fallback_cell: Vector2i = door_cell
-			var fallback_score: float = - INF
+			var fallback_score: float = -INF
 			var door_world = door_worlds[i]
 			for variant in reachable_cells:
 				var candidate: Vector2i = variant
@@ -209,7 +144,6 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 			"keys": key_cells,
 			"color": color
 		})
-
 	var door_index_offset = context.doors.size()
 	for i in range(door_data.size()):
 		var entry: Dictionary = door_data[i]
@@ -230,268 +164,6 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 				context.add_generated_node(key_node, main_scene)
 		LOGGER.log_generation("Maze+Keys door %d at %s with %d keys" % [door_index_offset + i, str(door_cell), key_count])
 
-	context.set_player_spawn_override(MAZE_UTILS.maze_cell_to_world(start_cell, maze_offset, cell_size))
-
-func _select_maze_door_cells(path: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, desired: int) -> Array:
-	var candidates: Array = []
-	for variant in path:
-		var cell: Vector2i = variant
-		if cell == start_cell or cell == exit_cell:
-			continue
-		candidates.append(cell)
-	if candidates.is_empty():
-		return []
-	var selected: Array = []
-	var min_spacing: float = cell_size * 3.5
-	var attempts: int = 0
-	while selected.size() < min(desired, candidates.size()) and attempts < 40:
-		var best_cell: Vector2i = candidates[0]
-		var best_score: float = - INF
-		for cell in candidates:
-			if selected.has(cell):
-				continue
-			var score = _maze_spread_score(cell, selected, start_cell, exit_cell, offset, cell_size)
-			if score > best_score:
-				best_score = score
-				best_cell = cell
-		selected.append(best_cell)
-		if selected.size() >= desired:
-			break
-		var filtered: Array = []
-		for cell in candidates:
-			if selected.has(cell):
-				continue
-			var keep := true
-			var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
-			for chosen in selected:
-				var chosen_world = MAZE_UTILS.maze_cell_to_world(chosen, offset, cell_size)
-				if chosen_world.distance_to(world) < min_spacing:
-					keep = false
-					break
-			if keep:
-				filtered.append(cell)
-		if filtered.is_empty() and min_spacing > cell_size * 1.2:
-			min_spacing *= 0.8
-			filtered = []
-			for cell in candidates:
-				if selected.has(cell):
-					continue
-				filtered.append(cell)
-		candidates = filtered
-		attempts += 1
-	return selected
-
-func _maze_spread_score(cell: Vector2i, existing: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float) -> float:
-	var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
-	var start_world = MAZE_UTILS.maze_cell_to_world(start_cell, offset, cell_size)
-	var exit_world = MAZE_UTILS.maze_cell_to_world(exit_cell, offset, cell_size)
-	var score = min(world.distance_to(start_world), world.distance_to(exit_world))
-	for chosen in existing:
-		var chosen_world = MAZE_UTILS.maze_cell_to_world(chosen, offset, cell_size)
-		score = min(score, world.distance_to(chosen_world))
-	return score
-
-func _collect_reachable_cells_before_door(grid: Array, start_cell: Vector2i, blocked_cells: Array) -> Array:
-	var rows = grid.size()
-	if rows <= 0:
-		return []
-	var cols = grid[0].size()
-	var queue: Array = []
-	var visited := {}
-	var reachable: Array = []
-	queue.append(start_cell)
-	visited[start_cell] = true
-	reachable.append(start_cell)
-	while not queue.is_empty():
-		var cell: Vector2i = queue.pop_front()
-		for dir in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
-			var next = cell + dir
-			if next.x < 0 or next.x >= cols or next.y < 0 or next.y >= rows:
-				continue
-			if grid[next.y][next.x]:
-				continue
-			if blocked_cells.has(next):
-				continue
-			if visited.has(next):
-				continue
-			visited[next] = true
-			reachable.append(next)
-			queue.append(next)
-	return reachable
-
-func _select_maze_key_cells(
-	reachable_cells: Array,
-	desired: int,
-	offset: Vector2,
-	cell_size: float,
-	door_cell: Vector2i,
-	start_cell: Vector2i,
-	exit_cell: Vector2i,
-	taken_cells: Array,
-	door_worlds: Array,
-	key_world_positions: Array,
-	start_world: Vector2,
-	exit_world: Vector2
-) -> Array:
-	var candidates: Array = []
-	for variant in reachable_cells:
-		var cell: Vector2i = variant
-		if cell == start_cell or cell == exit_cell or cell == door_cell:
-			continue
-		if taken_cells.has(cell):
-			continue
-		candidates.append(cell)
-	if candidates.is_empty() or desired <= 0:
-		return []
-	var result: Array = []
-	var min_spacing: float = cell_size * 2.5 # Increased from 2.0
-	var door_world = MAZE_UTILS.maze_cell_to_world(door_cell, offset, cell_size)
-	var attempts: int = 0
-	while result.size() < desired and attempts < 80 and not candidates.is_empty():
-		var best_cell: Vector2i = candidates[0]
-		var best_score: float = - INF
-		for cell in candidates:
-			var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
-			# Prioritize distance from door more heavily
-			var door_distance = world.distance_to(door_world)
-			var score = door_distance * 1.5 # Weight door distance more
-			score = min(score, world.distance_to(start_world))
-			score = min(score, world.distance_to(exit_world))
-			for door_world_other in door_worlds:
-				if door_world_other == door_world:
-					continue
-				score = min(score, world.distance_to(door_world_other))
-			for existing_world in key_world_positions:
-				score = min(score, world.distance_to(existing_world))
-			if score > best_score:
-				best_score = score
-				best_cell = cell
-		result.append(best_cell)
-		var best_world = MAZE_UTILS.maze_cell_to_world(best_cell, offset, cell_size)
-		key_world_positions.append(best_world)
-		taken_cells.append(best_cell)
-		var filtered: Array = []
-		for cell in candidates:
-			if cell == best_cell:
-				continue
-			var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
-			# Increased minimum distance from door from 1.6 to 2.5
-			if best_world.distance_to(world) >= min_spacing and world.distance_to(door_world) >= cell_size * 2.5:
-				filtered.append(cell)
-		candidates = filtered
-		if candidates.is_empty() and result.size() < desired and min_spacing > cell_size * 0.9:
-			min_spacing *= 0.85
-			for cell in reachable_cells:
-				if result.has(cell):
-					continue
-				if taken_cells.has(cell):
-					continue
-				if cell == start_cell or cell == exit_cell or cell == door_cell:
-					continue
-				var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
-				# Increased minimum distance from door from 1.4 to 2.0
-				if world.distance_to(door_world) < cell_size * 2.0:
-					continue
-				var too_close := false
-				for existing_world in key_world_positions:
-					if existing_world.distance_to(world) < min_spacing:
-						too_close = true
-						break
-				if too_close:
-					continue
-				candidates.append(cell)
-		attempts += 1
-	return result
-
-func _generate_maze_coins(grid: Array, start: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, main_scene) -> void:
-	var rows = grid.size()
-	var cols = grid[0].size()
-	var candidates: Array = []
-	for y in range(rows):
-		for x in range(cols):
-			if grid[y][x]:
-				continue
-			var cell = Vector2i(x, y)
-			if cell == start or cell == exit_cell:
-				continue
-			if (abs(cell.x - start.x) + abs(cell.y - start.y)) < 3:
-				continue
-			candidates.append(cell)
-	candidates.shuffle()
-	var desired = clamp(int(candidates.size() / 8.0), 5, 20)
-	for i in range(min(desired, candidates.size())):
-		var cell = candidates[i]
-		var world_pos = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
-		var coin = LEVEL_NODE_FACTORY.create_coin_node(context.coins.size(), world_pos)
-		context.coins.append(coin)
-		context.add_generated_node(coin, main_scene)
-
-func _get_random_maze_cell(cols: int, rows: int) -> Vector2i:
-	"""Get a random odd cell for maze generation that's not on the edge"""
-	var attempts = 0
-	while attempts < 100:
-		# Ensure we're well inside the maze, not on the outer edge
-		var x = randi_range(3, cols - 4) | 1 # Ensure odd and not on edge
-		var y = randi_range(3, rows - 4) | 1 # Ensure odd and not on edge
-		var cell = Vector2i(x, y)
-		# Double check we're well inside the maze boundaries
-		if cell.x >= 3 and cell.x < cols - 3 and cell.y >= 3 and cell.y < rows - 3:
-			return cell
-		attempts += 1
-	# Fallback to center if random fails
-	return Vector2i(int(cols / 2.0) | 1, int(rows / 2.0) | 1)
-
-func _fill_unreachable_areas(grid: Array, start_cell: Vector2i, offset: Vector2, cell_size: float, main_scene) -> void:
-	var job = MAZE_REACHABILITY_JOB.new()
-	var logger_callable := Callable()
-	if _debug_logging:
-		logger_callable = Callable(self, "_log_debug")
-	job.setup(
-		context,
-		main_scene,
-		grid.duplicate(true),
-		start_cell,
-		offset,
-		cell_size,
-		PLAYER_COLLISION_SIZE,
-		BLACK_SHADOW_COLOR,
-		_debug_logging,
-		logger_callable
-	)
-	if context and context is Node:
-		context.add_child(job)
-	elif main_scene and is_instance_valid(main_scene):
-		main_scene.call_deferred("add_child", job)
-	else:
-		job.queue_free()
-func _spawn_maze_walls(grid: Array, offset: Vector2, cell_size: float, main_scene) -> void:
-	var rows = grid.size()
-	var cols = grid[0].size()
-	var thickness = cell_size * context.MAZE_WALL_SIZE_RATIO
-	var half_thickness = thickness * 0.5
-	for y in range(rows):
-		var _start_x = -1
-		for x in range(cols):
-			if grid[y][x]:
-				continue
-			var base := offset + Vector2(x * cell_size, y * cell_size)
-			if y == 0 or grid[y - 1][x]:
-				var top_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(context.maze_walls.size(), cell_size, thickness, WALL_COLOR)
-				top_wall.position = base + Vector2(0.0, -half_thickness)
-				context.maze_walls.append(top_wall)
-				context.add_generated_node(top_wall, main_scene)
-			if y == rows - 1 or grid[y + 1][x]:
-				var bottom_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(context.maze_walls.size(), cell_size, thickness, WALL_COLOR)
-				bottom_wall.position = base + Vector2(0.0, cell_size - half_thickness)
-				context.maze_walls.append(bottom_wall)
-				context.add_generated_node(bottom_wall, main_scene)
-			if x == 0 or grid[y][x - 1]:
-				var left_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(context.maze_walls.size(), thickness, cell_size, WALL_COLOR)
-				left_wall.position = base + Vector2(-half_thickness, 0.0)
-				context.maze_walls.append(left_wall)
-				context.add_generated_node(left_wall, main_scene)
-			if x == cols - 1 or grid[y][x + 1]:
-				var right_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(context.maze_walls.size(), thickness, cell_size, WALL_COLOR)
-				right_wall.position = base + Vector2(cell_size - half_thickness, 0.0)
-				context.maze_walls.append(right_wall)
-				context.add_generated_node(right_wall, main_scene)
+func _build_layout(main_scene, player_start_position: Vector2) -> Dictionary:
+	_debug_logger.configure()
+	return _layout_builder.build(main_scene, player_start_position, _debug_logger, PLAYER_COLLISION_SIZE, BLACK_SHADOW_COLOR)

--- a/scripts/level_generators/key/KeyDoorPlanner.gd
+++ b/scripts/level_generators/key/KeyDoorPlanner.gd
@@ -1,0 +1,141 @@
+extends RefCounted
+class_name KeyDoorPlanner
+
+const LOGGER := preload("res://scripts/Logger.gd")
+const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
+
+var _context
+
+func _init(level_context):
+	_context = level_context
+
+func sample_far_points(count: int, offset: Vector2, level_width: float, level_height: float, min_distance: float) -> Array:
+	var points: Array = []
+	var attempts: int = 0
+	var spacing: float = min_distance
+	while points.size() < count and attempts < 400:
+		var candidate = Vector2(
+			randf_range(offset.x + 120.0, offset.x + level_width - 120.0),
+			randf_range(offset.y + 120.0, offset.y + level_height - 120.0)
+		)
+		var valid := true
+		for existing in points:
+			if existing.distance_to(candidate) < spacing:
+				valid = false
+				break
+		if valid:
+			points.append(candidate)
+		else:
+			attempts += 1
+			if attempts % 80 == 0 and spacing > 140.0:
+				spacing *= 0.85
+	if points.size() < count:
+		for i in range(count - points.size()):
+			var t = float(points.size() + i + 1) / float(count + 1)
+			var fallback = Vector2(
+				offset.x + level_width * t,
+				offset.y + level_height * randf_range(0.25, 0.75)
+			)
+			points.append(fallback)
+	return points
+
+func enforce_spacing(door_layouts: Array, offset: Vector2, level_width: float, min_gap: float, edge_margin: float) -> void:
+	if door_layouts.size() <= 1:
+		return
+	var sorted := door_layouts.duplicate()
+	sorted.sort_custom(func(a, b):
+		return float(a.get("center_x", 0.0)) < float(b.get("center_x", 0.0)))
+	var left_bound := offset.x + edge_margin
+	var right_bound := offset.x + level_width - edge_margin
+	var widths: Array[float] = []
+	var total_width := 0.0
+	for layout in sorted:
+		var width := float(layout.get("door_width", 48.0))
+		widths.append(width)
+		total_width += width
+	var desired_gap: float = min_gap
+	var separators: int = max(sorted.size() - 1, 0)
+	if separators > 0:
+		var available_span: float = max(right_bound - left_bound, 0.0)
+		var required_span: float = total_width + desired_gap * float(separators)
+		if required_span > available_span and available_span > total_width:
+			desired_gap = max(min_gap * 0.6, (available_span - total_width) / float(separators))
+			LOGGER.log_generation("Compressed door spacing from %.1f to %.1f to fit width" % [min_gap, desired_gap])
+	var total_spacing: float = desired_gap * float(separators)
+	var available_width: float = max(right_bound - left_bound, 0.0)
+	var start_offset: float = 0.0
+	if available_width > (total_width + total_spacing):
+		start_offset = (available_width - (total_width + total_spacing)) * 0.5
+	var cursor: float = left_bound + start_offset
+	for i in range(sorted.size()):
+		var layout: Dictionary = sorted[i]
+		var width: float = widths[i]
+		var half: float = width * 0.5
+		cursor = max(cursor, left_bound)
+		var center: float = clamp(cursor + half, left_bound + half, right_bound - half)
+		layout["center_x"] = center
+		cursor = center + half + desired_gap
+	for layout in sorted:
+		var original_index := int(layout.get("index", -1))
+		if original_index >= 0 and original_index < door_layouts.size():
+			var target: Dictionary = door_layouts[original_index]
+			target["center_x"] = layout["center_x"]
+			door_layouts[original_index] = target
+
+func pick_keys_for_door(
+	door_center: Vector2,
+	keys_needed: int,
+	offset: Vector2,
+	level_width: float,
+	level_height: float,
+	spawn_override: Vector2,
+	exit_position: Vector2,
+	used_positions: Array
+) -> Array:
+	var result: Array = []
+	if keys_needed <= 0:
+		return result
+	var min_spacing: float = 150.0
+	var attempts: int = 0
+	var accessible_x_max = door_center.x - 50.0
+	var accessible_x_min = offset.x + 90.0
+	while result.size() < keys_needed and attempts < 240:
+		var candidate = Vector2(
+			randf_range(accessible_x_min, accessible_x_max),
+			randf_range(offset.y + 90.0, offset.y + level_height - 90.0)
+		)
+		if candidate.x >= door_center.x - 30.0:
+			attempts += 1
+			continue
+		var collides_with_obstacle = false
+		for obstacle in _context.obstacles:
+			if obstacle and is_instance_valid(obstacle):
+				var obstacle_rect = LEVEL_UTILS.get_obstacle_rect(obstacle)
+				if obstacle_rect.has_point(candidate):
+					collides_with_obstacle = true
+					break
+		if collides_with_obstacle:
+			attempts += 1
+			continue
+		var score = min(candidate.distance_to(door_center), candidate.distance_to(spawn_override))
+		score = min(score, candidate.distance_to(exit_position))
+		for used in used_positions:
+			score = min(score, candidate.distance_to(used))
+		for existing in result:
+			score = min(score, candidate.distance_to(existing))
+		if score < min_spacing:
+			attempts += 1
+			if attempts % 60 == 0 and min_spacing > 90.0:
+				min_spacing *= 0.9
+			continue
+		result.append(candidate)
+		used_positions.append(candidate)
+	if result.size() < keys_needed:
+		while result.size() < keys_needed:
+			var fallback = Vector2(
+				randf_range(accessible_x_min, accessible_x_max),
+				offset.y + level_height * randf_range(0.25, 0.75)
+			)
+			result.append(fallback)
+			used_positions.append(fallback)
+	return result

--- a/scripts/level_generators/maze/MazeCoinDistributor.gd
+++ b/scripts/level_generators/maze/MazeCoinDistributor.gd
@@ -1,0 +1,35 @@
+extends RefCounted
+class_name MazeCoinDistributor
+
+const MAZE_UTILS := preload("res://scripts/level_generators/MazeUtils.gd")
+const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+
+var _context
+
+func _init(level_context):
+	_context = level_context
+
+func populate(grid: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, main_scene) -> void:
+	var rows = grid.size()
+	if rows <= 0:
+		return
+	var cols = grid[0].size()
+	var candidates: Array = []
+	for y in range(rows):
+		for x in range(cols):
+			if grid[y][x]:
+				continue
+			var cell = Vector2i(x, y)
+			if cell == start_cell or cell == exit_cell:
+				continue
+			if (abs(cell.x - start_cell.x) + abs(cell.y - start_cell.y)) < 3:
+				continue
+			candidates.append(cell)
+	candidates.shuffle()
+	var desired = clamp(int(candidates.size() / 8.0), 5, 20)
+	for i in range(min(desired, candidates.size())):
+		var cell = candidates[i]
+		var world_pos = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+		var coin = LEVEL_NODE_FACTORY.create_coin_node(_context.coins.size(), world_pos)
+		_context.coins.append(coin)
+		_context.add_generated_node(coin, main_scene)

--- a/scripts/level_generators/maze/MazeDebugLogger.gd
+++ b/scripts/level_generators/maze/MazeDebugLogger.gd
@@ -1,0 +1,37 @@
+extends RefCounted
+class_name MazeDebugLogger
+
+const DEBUG_LOG_DIR := "user://logs"
+const DEBUG_LOG_FILE := "maze_debug.log"
+
+var _enabled := false
+var _file: FileAccess = null
+
+func configure() -> void:
+	_enabled = true
+	if Engine.has_meta("maze_debug_logging"):
+		_enabled = bool(Engine.get_meta("maze_debug_logging"))
+	if not _enabled:
+		return
+	_open_file_if_needed()
+	if _file:
+		_file.store_line("MazeGenerator debug log started")
+		_file.flush()
+
+func is_enabled() -> bool:
+	return _enabled
+
+func log(message: String) -> void:
+	if not _enabled:
+		return
+	_open_file_if_needed()
+	if _file:
+		_file.store_line(message)
+		_file.flush()
+
+func _open_file_if_needed() -> void:
+	if _file:
+		return
+	DirAccess.make_dir_recursive_absolute(DEBUG_LOG_DIR)
+	var path := "%s/%s" % [DEBUG_LOG_DIR, DEBUG_LOG_FILE]
+	_file = FileAccess.open(path, FileAccess.WRITE)

--- a/scripts/level_generators/maze/MazeDoorAndKeyPlanner.gd
+++ b/scripts/level_generators/maze/MazeDoorAndKeyPlanner.gd
@@ -1,0 +1,172 @@
+extends RefCounted
+class_name MazeDoorAndKeyPlanner
+
+const MAZE_UTILS := preload("res://scripts/level_generators/MazeUtils.gd")
+
+func select_door_cells(path: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, desired: int) -> Array:
+	var candidates: Array = []
+	for variant in path:
+		var cell: Vector2i = variant
+		if cell == start_cell or cell == exit_cell:
+			continue
+		candidates.append(cell)
+	if candidates.is_empty():
+		return []
+	var selected: Array = []
+	var min_spacing: float = cell_size * 3.5
+	var attempts: int = 0
+	while selected.size() < min(desired, candidates.size()) and attempts < 40:
+		var best_cell: Vector2i = candidates[0]
+		var best_score: float = -INF
+		for cell in candidates:
+			if selected.has(cell):
+				continue
+			var score = _maze_spread_score(cell, selected, start_cell, exit_cell, offset, cell_size)
+			if score > best_score:
+				best_score = score
+				best_cell = cell
+		selected.append(best_cell)
+		if selected.size() >= desired:
+			break
+		var filtered: Array = []
+		for cell in candidates:
+			if selected.has(cell):
+				continue
+			var keep := true
+			var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+			for chosen in selected:
+				var chosen_world = MAZE_UTILS.maze_cell_to_world(chosen, offset, cell_size)
+				if chosen_world.distance_to(world) < min_spacing:
+					keep = false
+					break
+			if keep:
+				filtered.append(cell)
+		if filtered.is_empty() and min_spacing > cell_size * 1.2:
+			min_spacing *= 0.8
+			filtered = []
+			for cell in candidates:
+				if selected.has(cell):
+					continue
+				filtered.append(cell)
+		candidates = filtered
+		attempts += 1
+	return selected
+
+func collect_reachable_cells_before_door(grid: Array, start_cell: Vector2i, blocked_cells: Array) -> Array:
+	var rows = grid.size()
+	if rows <= 0:
+		return []
+	var cols = grid[0].size()
+	var queue: Array = []
+	var visited := {}
+	var reachable: Array = []
+	queue.append(start_cell)
+	visited[start_cell] = true
+	reachable.append(start_cell)
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		for dir in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
+			var next = cell + dir
+			if next.x < 0 or next.x >= cols or next.y < 0 or next.y >= rows:
+				continue
+			if grid[next.y][next.x]:
+				continue
+			if blocked_cells.has(next):
+				continue
+			if visited.has(next):
+				continue
+			visited[next] = true
+			reachable.append(next)
+			queue.append(next)
+	return reachable
+
+func select_key_cells(
+	reachable_cells: Array,
+	desired: int,
+	offset: Vector2,
+	cell_size: float,
+	door_cell: Vector2i,
+	start_cell: Vector2i,
+	exit_cell: Vector2i,
+	taken_cells: Array,
+	door_worlds: Array,
+	key_world_positions: Array,
+	start_world: Vector2,
+	exit_world: Vector2
+) -> Array:
+	var candidates: Array = []
+	for variant in reachable_cells:
+		var cell: Vector2i = variant
+		if cell == start_cell or cell == exit_cell or cell == door_cell:
+			continue
+		if taken_cells.has(cell):
+			continue
+		candidates.append(cell)
+	if candidates.is_empty() or desired <= 0:
+		return []
+	var result: Array = []
+	var min_spacing: float = cell_size * 2.5
+	var door_world = MAZE_UTILS.maze_cell_to_world(door_cell, offset, cell_size)
+	var attempts: int = 0
+	while result.size() < desired and attempts < 80 and not candidates.is_empty():
+		var best_cell: Vector2i = candidates[0]
+		var best_score: float = -INF
+		for cell in candidates:
+			var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+			var door_distance = world.distance_to(door_world)
+			var score = door_distance * 1.5
+			score = min(score, world.distance_to(start_world))
+			score = min(score, world.distance_to(exit_world))
+			for door_world_other in door_worlds:
+				if door_world_other == door_world:
+					continue
+				score = min(score, world.distance_to(door_world_other))
+			for existing_world in key_world_positions:
+				score = min(score, world.distance_to(existing_world))
+			if score > best_score:
+				best_score = score
+				best_cell = cell
+		result.append(best_cell)
+		var best_world = MAZE_UTILS.maze_cell_to_world(best_cell, offset, cell_size)
+		key_world_positions.append(best_world)
+		taken_cells.append(best_cell)
+		var filtered: Array = []
+		for cell in candidates:
+			if cell == best_cell:
+				continue
+			var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+			if best_world.distance_to(world) >= min_spacing and world.distance_to(door_world) >= cell_size * 2.5:
+				filtered.append(cell)
+		candidates = filtered
+		if candidates.is_empty() and result.size() < desired and min_spacing > cell_size * 0.9:
+			min_spacing *= 0.85
+			for cell in reachable_cells:
+				if result.has(cell):
+					continue
+				if taken_cells.has(cell):
+					continue
+				if cell == start_cell or cell == exit_cell or cell == door_cell:
+					continue
+				var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+				if world.distance_to(door_world) < cell_size * 2.0:
+					continue
+				var too_close := false
+				for existing_world in key_world_positions:
+					if existing_world.distance_to(world) < min_spacing:
+						too_close = true
+						break
+				if too_close:
+					continue
+				candidates.append(cell)
+		attempts += 1
+	return result
+
+func _maze_spread_score(cell: Vector2i, existing: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float) -> float:
+	var world = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+	var start_world = MAZE_UTILS.maze_cell_to_world(start_cell, offset, cell_size)
+	var exit_world = MAZE_UTILS.maze_cell_to_world(exit_cell, offset, cell_size)
+	var score = min(world.distance_to(start_world), world.distance_to(exit_world))
+	for chosen in existing:
+		var chosen_world = MAZE_UTILS.maze_cell_to_world(chosen, offset, cell_size)
+		score = min(score, world.distance_to(chosen_world))
+	return score

--- a/scripts/level_generators/maze/MazeLayoutBuilder.gd
+++ b/scripts/level_generators/maze/MazeLayoutBuilder.gd
@@ -1,0 +1,131 @@
+extends RefCounted
+class_name MazeLayoutBuilder
+
+const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
+const MAZE_UTILS := preload("res://scripts/level_generators/MazeUtils.gd")
+const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+const MAZE_REACHABILITY_JOB: GDScript = preload("res://scripts/level_generators/MazeReachabilityJob.gd")
+const WALL_COLOR := Color(0.15, 0.18, 0.28, 1)
+
+var _context
+
+func _init(level_context):
+	_context = level_context
+
+func build(
+	main_scene,
+	player_start_position: Vector2,
+	debug_logger,
+	player_collision_size: float,
+	shadow_color: Color
+) -> Dictionary:
+	var dims = LEVEL_UTILS.get_scaled_level_dimensions(_context.current_level_size)
+	var level_width: float = float(dims.width)
+	var level_height: float = float(dims.height)
+	var offset = Vector2(dims.offset_x, dims.offset_y)
+	var cell_size = _context.MAZE_BASE_CELL_SIZE
+	var cols = int(floor(level_width / cell_size))
+	var rows = int(floor(level_height / cell_size))
+	cols = max(cols | 1, 5)
+	rows = max(rows | 1, 5)
+	var maze_width = cols * cell_size
+	var maze_height = rows * cell_size
+	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
+	var start_cell: Vector2i = _choose_start_cell(player_start_position, maze_offset, cell_size, cols, rows)
+	var grid = MAZE_UTILS.init_maze_grid(cols, rows)
+	MAZE_UTILS.carve_maze(grid, start_cell, cols, rows)
+	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
+	_fill_unreachable_areas(main_scene, grid, start_cell, maze_offset, cell_size, player_collision_size, shadow_color, debug_logger)
+	var start_world = MAZE_UTILS.maze_cell_to_world(start_cell, maze_offset, cell_size)
+	_context.set_player_spawn_override(start_world)
+	return {
+		"grid": grid,
+		"cols": cols,
+		"rows": rows,
+		"cell_size": cell_size,
+		"maze_offset": maze_offset,
+		"start_cell": start_cell,
+		"start_world": start_world
+	}
+
+func _choose_start_cell(player_start_position: Vector2, maze_offset: Vector2, cell_size: float, cols: int, rows: int) -> Vector2i:
+	if _context.current_level_size >= 1.2:
+		return _get_random_maze_cell(cols, rows)
+	var start_cell = MAZE_UTILS.world_to_maze_cell(player_start_position, maze_offset, cell_size)
+	return MAZE_UTILS.ensure_odd_cell(start_cell, cols, rows)
+
+func _spawn_maze_walls(grid: Array, offset: Vector2, cell_size: float, main_scene) -> void:
+	var rows = grid.size()
+	var cols = grid[0].size()
+	var thickness = cell_size * _context.MAZE_WALL_SIZE_RATIO
+	var half_thickness = thickness * 0.5
+	for y in range(rows):
+		for x in range(cols):
+			if grid[y][x]:
+				continue
+			var base := offset + Vector2(x * cell_size, y * cell_size)
+			if y == 0 or grid[y - 1][x]:
+				var top_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), cell_size, thickness, WALL_COLOR)
+				top_wall.position = base + Vector2(0.0, -half_thickness)
+				_context.maze_walls.append(top_wall)
+				_context.add_generated_node(top_wall, main_scene)
+			if y == rows - 1 or grid[y + 1][x]:
+				var bottom_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), cell_size, thickness, WALL_COLOR)
+				bottom_wall.position = base + Vector2(0.0, cell_size - half_thickness)
+				_context.maze_walls.append(bottom_wall)
+				_context.add_generated_node(bottom_wall, main_scene)
+			if x == 0 or grid[y][x - 1]:
+				var left_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), thickness, cell_size, WALL_COLOR)
+				left_wall.position = base + Vector2(-half_thickness, 0.0)
+				_context.maze_walls.append(left_wall)
+				_context.add_generated_node(left_wall, main_scene)
+			if x == cols - 1 or grid[y][x + 1]:
+				var right_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), thickness, cell_size, WALL_COLOR)
+				right_wall.position = base + Vector2(cell_size - half_thickness, 0.0)
+				_context.maze_walls.append(right_wall)
+				_context.add_generated_node(right_wall, main_scene)
+
+func _fill_unreachable_areas(
+	main_scene,
+	grid: Array,
+	start_cell: Vector2i,
+	offset: Vector2,
+	cell_size: float,
+	player_collision_size: float,
+	shadow_color: Color,
+	debug_logger
+) -> void:
+	var job = MAZE_REACHABILITY_JOB.new()
+	var logger_callable := Callable()
+	var debug_enabled: bool = debug_logger and debug_logger.is_enabled()
+	if debug_enabled:
+		logger_callable = Callable(debug_logger, "log")
+	job.setup(
+		_context,
+		main_scene,
+		grid.duplicate(true),
+		start_cell,
+		offset,
+		cell_size,
+		player_collision_size,
+		shadow_color,
+		debug_enabled,
+		logger_callable
+	)
+	if _context and _context is Node:
+		_context.add_child(job)
+	elif main_scene and is_instance_valid(main_scene):
+		main_scene.call_deferred("add_child", job)
+	else:
+		job.queue_free()
+
+func _get_random_maze_cell(cols: int, rows: int) -> Vector2i:
+	var attempts = 0
+	while attempts < 100:
+		var x = randi_range(3, cols - 4) | 1
+		var y = randi_range(3, rows - 4) | 1
+		var cell = Vector2i(x, y)
+		if cell.x >= 3 and cell.x < cols - 3 and cell.y >= 3 and cell.y < rows - 3:
+			return cell
+		attempts += 1
+	return Vector2i(int(cols / 2.0) | 1, int(rows / 2.0) | 1)

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -22,7 +22,7 @@ var ui_controller = null
 var game_flow_controller = null
 var coins: Array[Area2D] = []
 var keys: Array[Area2D] = []
-var doors: Array[StaticBody2D] = []
+var doors: Array = []
 var _object_binder = LEVEL_OBJECT_BINDER.new()
 var _generation_service = LEVEL_GENERATION_SERVICE.new()
 
@@ -50,7 +50,7 @@ func generate_new_level() -> void:
 	_generation_service.reset_runtime_state()
 	coins = [] as Array[Area2D]
 	keys = [] as Array[Area2D]
-	doors = [] as Array[StaticBody2D]
+	doors = [] as Array
 	if game_flow_controller:
 		game_flow_controller.handle_timer_for_game_state()
 	await main.get_tree().process_frame

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -4,16 +4,36 @@ extends RefCounted
 const LOGGER := preload("res://scripts/Logger.gd")
 const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
 const GAME_STATE := preload("res://scripts/GameState.gd")
+const LEVEL_OBJECT_BINDER := preload("res://scripts/main/level/LevelObjectBinder.gd")
+const LEVEL_GENERATION_SERVICE := preload("res://scripts/main/level/LevelGenerationService.gd")
+
+const LEVEL_TYPE_LABELS := [
+	"Obstacles+Coins",
+	"Keys",
+	"Maze",
+	"Maze+Coins",
+	"Maze+Keys",
+	"Random",
+	"Challenge"
+]
 
 var main = null
 var ui_controller = null
 var game_flow_controller = null
 var coins: Array[Area2D] = []
 var keys: Array[Area2D] = []
+var _object_binder = LEVEL_OBJECT_BINDER.new()
+var _generation_service = LEVEL_GENERATION_SERVICE.new()
 
 func setup(main_ref, ui_controller_ref) -> void:
 	main = main_ref
 	ui_controller = ui_controller_ref
+	if _object_binder == null:
+		_object_binder = LEVEL_OBJECT_BINDER.new()
+	_object_binder.setup(main, ui_controller)
+	if _generation_service == null:
+		_generation_service = LEVEL_GENERATION_SERVICE.new()
+	_generation_service.setup(main, ui_controller)
 
 func set_game_flow_controller(controller) -> void:
 	game_flow_controller = controller
@@ -23,126 +43,29 @@ func generate_new_level() -> void:
 	if main.game_state.current_level > 7:
 		main.game_state.reset_to_start()
 		LOGGER.log_game_mode("Level exceeded cap, reset to level %d" % main.game_state.current_level)
-
 	var level_type: int = main.game_state.get_current_level_type()
-	var generation_level_size: float = main.game_state.current_level_size
-	if level_type == GAME_STATE.LevelType.KEYS:
-		generation_level_size = min(generation_level_size + 0.35, main.game_state.max_level_size + 0.25)
-
+	var generation_level_size: float = _generation_service.calculate_generation_size(level_type)
 	LOGGER.log_generation("Generating level %d (size: %.2f)" % [main.game_state.current_level, generation_level_size])
-
-	main.level_start_time = Time.get_ticks_msec() / 1000.0
-	main.collected_coins = main.previous_coin_count
-	main.exit_active = false
-	main.exit = null
+	_generation_service.reset_runtime_state()
 	coins = [] as Array[Area2D]
 	keys = [] as Array[Area2D]
-	main.game_state.set_state(GAME_STATE.GameStateType.PLAYING)
-	if main.game_state.current_state != GAME_STATE.GameStateType.PLAYING:
-		LOGGER.log_game_mode("Game state corrected to PLAYING before generation")
-		main.game_state.set_state(GAME_STATE.GameStateType.PLAYING)
-
 	if game_flow_controller:
 		game_flow_controller.handle_timer_for_game_state()
-
 	await main.get_tree().process_frame
-
 	LEVEL_UTILS.update_level_boundaries(generation_level_size, main.play_area, main.boundaries)
 	position_player_within_level(generation_level_size)
-
-	var level_type_names: Array[String] = ["Obstacles+Coins", "Keys", "Maze", "Maze+Coins", "Maze+Keys", "Random", "Challenge"]
-	var level_type_label: String = level_type_names[level_type] if level_type < level_type_names.size() else str(level_type)
-	LOGGER.log_game_mode("Preparing level type: %s" % level_type_label)
-
-	var generate_obstacles: bool = main.game_state.generate_obstacles
-	var generate_coins: bool = main.game_state.generate_coins
-	if level_type == GAME_STATE.LevelType.KEYS:
-		generate_obstacles = false
-		generate_coins = false
-	elif level_type == GAME_STATE.LevelType.MAZE or level_type == GAME_STATE.LevelType.MAZE_COINS or level_type == GAME_STATE.LevelType.MAZE_KEYS:
-		generate_obstacles = false
-		generate_coins = false
-
-	if main.level_generator and is_instance_valid(main.level_generator):
-		main.level_generator.generate_level(
-			generation_level_size,
-			generate_obstacles,
-			generate_coins,
-			main.game_state.min_exit_distance_ratio,
-			main.game_state.use_full_map_coverage,
-			main,
-			main.game_state.current_level,
-			main.previous_coin_count,
-			main.player.global_position if main.player else LEVEL_UTILS.PLAYER_START,
-			level_type
-		)
-		main.exit = main.level_generator.get_generated_exit()
-		coins = main.level_generator.get_generated_coins() as Array[Area2D]
-		keys = main.level_generator.get_generated_keys() as Array[Area2D]
-		var spawn_override_variant: Variant = main.level_generator.get_player_spawn_override()
-		var has_spawn_override: bool = typeof(spawn_override_variant) == TYPE_VECTOR2
-		var spawn_override: Vector2 = spawn_override_variant if has_spawn_override else Vector2.ZERO
-		if main.exit:
-			LOGGER.log_generation("Exit generated at %s" % [main.exit.position])
-		else:
-			LOGGER.log_generation("No exit generated")
-		LOGGER.log_generation("Coins generated: %d" % coins.size())
-		LOGGER.log_generation("Keys generated: %d" % keys.size())
-		if main.timer_manager:
-			var timer_start_position: Vector2 = spawn_override if has_spawn_override else (main.player.global_position if main.player else LEVEL_UTILS.PLAYER_START)
-			var maze_path_length: float = main.level_generator.get_last_maze_path_length() if main.level_generator else 0.0
-			main.game_time = main.timer_manager.calculate_level_time(
-				main.game_state.current_level,
-				coins,
-				main.exit.position if main.exit else Vector2(),
-				timer_start_position,
-				level_type,
-				maze_path_length
-			)
-		else:
-			main.game_time = 30.0
-		for coin in coins:
-			var coin_area: Area2D = coin
-			if coin_area and is_instance_valid(coin_area):
-				var coin_callable: Callable = Callable(main, "_on_coin_collected").bind(coin_area)
-				if not coin_area.body_entered.is_connected(coin_callable):
-					coin_area.body_entered.connect(coin_callable)
-		main.total_coins = coins.size()
-		main.collected_coins = 0
-		if main.total_coins == 0:
-			main.previous_coin_count = 0
-		if main.exit and is_instance_valid(main.exit):
-			var exit_callable: Callable = Callable(main, "_on_exit_entered")
-			if not main.exit.body_entered.is_connected(exit_callable):
-				main.exit.body_entered.connect(exit_callable)
-		main.collected_keys_count = 0
-		main.total_keys = keys.size()
-		for key in keys:
-			var key_node: Area2D = key
-			if key_node and is_instance_valid(key_node) and key_node.has_signal("key_collected"):
-				var key_callable: Callable = Callable(main, "_on_key_collected")
-				if not key_node.is_connected("key_collected", key_callable):
-					key_node.connect("key_collected", key_callable)
-		main.timer.wait_time = main.game_time
-		main.timer.stop()
-		main.timer.start()
-		ui_controller.update_coin_display(main.total_coins, main.collected_coins)
-		ui_controller.setup_key_ui(keys)
-		main.exit_active = main.collected_coins >= main.total_coins
-		ui_controller.update_exit_state(main.exit_active, main.exit)
-		ui_controller.update_timer_display(main.game_time)
-		ui_controller.update_level_progress(main.game_state.get_level_progress_text())
-		if has_spawn_override and main.player and is_instance_valid(main.player):
-			main.player.global_position = spawn_override
-			main.player.position = spawn_override
-			main.player.rotation = 0.0
-			LOGGER.log_generation("Level ready: time %.2f, coins %d" % [main.game_time, main.total_coins])
-		else:
-			LOGGER.log_generation("Level ready: time %.2f, coins %d (default spawn)" % [main.game_time, main.total_coins])
+	_log_level_type(level_type)
+	var generation_flags := _generation_service.determine_generation_flags(level_type)
+	var generator_success := _generation_service.invoke_level_generator(level_type, generation_level_size, generation_flags)
+	if generator_success:
+		var binding_result: Dictionary = {}
+		if _object_binder:
+			binding_result = _object_binder.bind_from_generator(main.level_generator)
+		var outcome := _generation_service.apply_generation_outcome(binding_result, level_type)
+		coins = outcome.get("coins", [] as Array[Area2D])
+		keys = outcome.get("keys", [] as Array[Area2D])
 	else:
-		LOGGER.log_error("LevelGenerator missing when attempting to generate level")
 		main.game_time = 30.0
-
 	main.level_initializing = false
 
 func position_player_within_level(level_size: float = -1.0) -> void:
@@ -170,7 +93,6 @@ func handle_coin_collected(body: Node, coin: Area2D) -> void:
 				main.player.apply_speed_boost()
 		coin.queue_free()
 		coins.erase(coin)
-
 	main.exit_active = main.collected_coins >= main.total_coins
 	ui_controller.update_coin_display(main.total_coins, main.collected_coins)
 	ui_controller.update_exit_state(main.exit_active, main.exit)
@@ -201,11 +123,9 @@ func clear_level_objects() -> void:
 		)
 		if should_clear and is_instance_valid(node_child):
 			node_child.queue_free()
-
 	if main.level_generator and is_instance_valid(main.level_generator):
 		main.level_generator.clear_existing_objects()
 		LOGGER.log_generation("LevelGenerator cleared existing objects")
-
 	main.exit = null
 	coins = [] as Array[Area2D]
 	keys = [] as Array[Area2D]
@@ -219,3 +139,7 @@ func clear_level_objects() -> void:
 
 func get_active_coins() -> Array[Area2D]:
 	return coins
+
+func _log_level_type(level_type: int) -> void:
+	var label: String = LEVEL_TYPE_LABELS[level_type] if level_type < LEVEL_TYPE_LABELS.size() else str(level_type)
+	LOGGER.log_game_mode("Preparing level type: %s" % label)

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -22,6 +22,7 @@ var ui_controller = null
 var game_flow_controller = null
 var coins: Array[Area2D] = []
 var keys: Array[Area2D] = []
+var doors: Array[StaticBody2D] = []
 var _object_binder = LEVEL_OBJECT_BINDER.new()
 var _generation_service = LEVEL_GENERATION_SERVICE.new()
 
@@ -49,6 +50,7 @@ func generate_new_level() -> void:
 	_generation_service.reset_runtime_state()
 	coins = [] as Array[Area2D]
 	keys = [] as Array[Area2D]
+	doors = [] as Array[StaticBody2D]
 	if game_flow_controller:
 		game_flow_controller.handle_timer_for_game_state()
 	await main.get_tree().process_frame
@@ -64,6 +66,7 @@ func generate_new_level() -> void:
 		var outcome := _generation_service.apply_generation_outcome(binding_result, level_type)
 		coins = outcome.get("coins", [] as Array[Area2D])
 		keys = outcome.get("keys", [] as Array[Area2D])
+		doors = outcome.get("doors", [] as Array[StaticBody2D])
 	else:
 		main.game_time = 30.0
 	main.level_initializing = false
@@ -108,6 +111,10 @@ func handle_key_collected(door_id: int) -> void:
 	ui_controller.mark_key_collected(door_id)
 	ui_controller.update_key_status_display(main.collected_keys_count)
 
+func handle_door_opened(door_id: int, door_color: Color) -> void:
+	if ui_controller:
+		ui_controller.mark_door_opened(door_id, door_color)
+
 func clear_level_objects() -> void:
 	LOGGER.log_generation("Clearing previously generated objects")
 	for child in main.get_children():
@@ -129,6 +136,7 @@ func clear_level_objects() -> void:
 	main.exit = null
 	coins = [] as Array[Area2D]
 	keys = [] as Array[Area2D]
+	doors = [] as Array[StaticBody2D]
 	main.total_coins = 0
 	main.collected_coins = 0
 	main.total_keys = 0

--- a/scripts/main/UIController.gd
+++ b/scripts/main/UIController.gd
@@ -14,6 +14,8 @@ var restart_button: Button = null
 var menu_button: Button = null
 var key_container: Control = null
 var key_status_container: Control = null
+var door_container: Control = null
+var door_status_container: Control = null
 var _key_ui_manager
 
 var key_checkbox_nodes: Array[CheckBox]:
@@ -31,6 +33,8 @@ func setup(
 	menu_button_ref: Button,
 	key_container_ref: Control,
 	key_status_container_ref: Control,
+	door_container_ref: Control,
+	door_status_container_ref: Control,
 	speed_label_ref: Label = null
 ) -> void:
 	main = main_ref
@@ -43,10 +47,12 @@ func setup(
 	menu_button = menu_button_ref
 	key_container = key_container_ref
 	key_status_container = key_status_container_ref
+	door_container = door_container_ref
+	door_status_container = door_status_container_ref
 	speed_label = speed_label_ref
 	if _key_ui_manager == null:
 		_key_ui_manager = KEY_UI_MANAGER.new()
-	_key_ui_manager.setup_containers(key_container, key_status_container)
+	_key_ui_manager.setup_containers(key_container, key_status_container, door_container, door_status_container)
 
 func update_timer_display(game_time: float) -> void:
 	if timer_label:
@@ -89,6 +95,11 @@ func setup_key_ui(key_nodes: Array[Area2D]) -> void:
 		return
 	_key_ui_manager.build_from_keys(key_nodes)
 
+func setup_door_ui(door_nodes: Array[StaticBody2D]) -> void:
+	if _key_ui_manager == null:
+		return
+	_key_ui_manager.build_from_doors(door_nodes)
+
 func update_key_status_display(collected_keys: int) -> void:
 	if _key_ui_manager:
 		_key_ui_manager.update_key_status_display(collected_keys)
@@ -96,6 +107,10 @@ func update_key_status_display(collected_keys: int) -> void:
 func mark_key_collected(door_id: int) -> void:
 	if _key_ui_manager:
 		_key_ui_manager.mark_key_collected(door_id)
+
+func mark_door_opened(door_id: int, door_color: Color) -> void:
+	if _key_ui_manager:
+		_key_ui_manager.mark_door_opened(door_id, door_color)
 
 func show_game_over_ui(restart_text: String) -> void:
 	if game_over_label:

--- a/scripts/main/UIController.gd
+++ b/scripts/main/UIController.gd
@@ -1,6 +1,8 @@
 class_name UIController
 extends RefCounted
 
+const KEY_UI_MANAGER := preload("res://scripts/main/ui/KeyUIManager.gd")
+
 var main = null
 var timer_label: Label = null
 var coin_label: Label = null
@@ -12,11 +14,11 @@ var restart_button: Button = null
 var menu_button: Button = null
 var key_container: Control = null
 var key_status_container: Control = null
-var key_checkbox_nodes: Array[CheckBox] = []
-var key_colors: Array[Color] = []
-var key_door_ids: Array[int] = []
-var collected_key_counts: Dictionary = {}
-var key_slot_counts: Dictionary = {}
+var _key_ui_manager
+
+var key_checkbox_nodes: Array[CheckBox]:
+	get:
+		return _key_ui_manager.key_checkbox_nodes if _key_ui_manager else [] as Array[CheckBox]
 
 func setup(
 	main_ref,
@@ -42,6 +44,9 @@ func setup(
 	key_container = key_container_ref
 	key_status_container = key_status_container_ref
 	speed_label = speed_label_ref
+	if _key_ui_manager == null:
+		_key_ui_manager = KEY_UI_MANAGER.new()
+	_key_ui_manager.setup_containers(key_container, key_status_container)
 
 func update_timer_display(game_time: float) -> void:
 	if timer_label:
@@ -76,99 +81,21 @@ func update_exit_state(exit_active: bool, exit_node: Node) -> void:
 		exit_body.color = Color(0.4, 0.4, 0.4, 1)
 
 func clear_key_ui() -> void:
-	key_checkbox_nodes.clear()
-	key_colors.clear()
-	key_door_ids.clear()
-	collected_key_counts.clear()
-	key_slot_counts.clear()
-	if key_status_container:
-		for child in key_status_container.get_children():
-			var control_child: Control = child as Control
-			if control_child and is_instance_valid(control_child):
-				control_child.queue_free()
-	if key_container:
-		key_container.visible = false
+	if _key_ui_manager:
+		_key_ui_manager.clear()
 
 func setup_key_ui(key_nodes: Array[Area2D]) -> void:
-	clear_key_ui()
-	if key_nodes == null:
-		key_nodes = [] as Array[Area2D]
-	var total_keys: int = key_nodes.size()
-	if total_keys <= 0 or key_status_container == null:
+	if _key_ui_manager == null:
 		return
-	if key_container:
-		key_container.visible = true
-	for index in range(total_keys):
-		var checkbox: CheckBox = CheckBox.new()
-		checkbox.disabled = true
-		checkbox.focus_mode = Control.FOCUS_NONE
-		checkbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		checkbox.button_pressed = false
-		var key_node: Area2D = key_nodes[index] if index < key_nodes.size() else null
-		var color: Color = Color(0.9, 0.9, 0.2, 1.0)
-		if key_node and key_node.has_meta("group_color"):
-			color = key_node.get_meta("group_color")
-		key_colors.append(color)
-		var door_identifier: int = index
-		if key_node and key_node.has_method("get"):
-			var door_value = key_node.get("door_id")
-			if door_value != null:
-				door_identifier = int(door_value)
-		key_door_ids.append(door_identifier)
-		key_slot_counts[door_identifier] = key_slot_counts.get(door_identifier, 0) + 1
-		checkbox.modulate = color
-		key_status_container.add_child(checkbox)
-		key_checkbox_nodes.append(checkbox)
-	collected_key_counts.clear()
-	_refresh_key_checkboxes()
+	_key_ui_manager.build_from_keys(key_nodes)
 
 func update_key_status_display(collected_keys: int) -> void:
-	collected_key_counts.clear()
-	var remaining: int = clamp(collected_keys, 0, key_door_ids.size())
-	for door_id in key_door_ids:
-		if remaining <= 0:
-			break
-		var total_slots: int = int(key_slot_counts.get(door_id, 0))
-		if total_slots <= 0:
-			continue
-		var current: int = int(collected_key_counts.get(door_id, 0))
-		if current >= total_slots:
-			continue
-		collected_key_counts[door_id] = current + 1
-		remaining -= 1
-	_refresh_key_checkboxes()
+	if _key_ui_manager:
+		_key_ui_manager.update_key_status_display(collected_keys)
 
 func mark_key_collected(door_id: int) -> void:
-	var total_slots: int = int(key_slot_counts.get(door_id, 0))
-	if total_slots <= 0:
-		return
-	var collected: int = int(collected_key_counts.get(door_id, 0))
-	if collected >= total_slots:
-		return
-	collected_key_counts[door_id] = collected + 1
-	_refresh_key_checkboxes()
-
-func _refresh_key_checkboxes() -> void:
-	var per_door_usage: Dictionary = {}
-	for index in range(key_checkbox_nodes.size()):
-		var checkbox: CheckBox = key_checkbox_nodes[index]
-		if checkbox == null or not is_instance_valid(checkbox):
-			continue
-		var door_identifier: int = key_door_ids[index] if index < key_door_ids.size() else index
-		var collected_total: int = int(collected_key_counts.get(door_identifier, 0))
-		var used: int = int(per_door_usage.get(door_identifier, 0))
-		var is_collected: bool = used < collected_total
-		per_door_usage[door_identifier] = used + 1
-		checkbox.button_pressed = is_collected
-		var base_color: Color = key_colors[index] if index < key_colors.size() else Color(0.9, 0.9, 0.2, 1.0)
-		if is_collected:
-			var highlight: Color = base_color.lightened(0.35)
-			highlight.a = base_color.a
-			checkbox.modulate = highlight
-		else:
-			checkbox.modulate = base_color
-	if key_container:
-		key_container.visible = key_checkbox_nodes.size() > 0
+	if _key_ui_manager:
+		_key_ui_manager.mark_key_collected(door_id)
 
 func show_game_over_ui(restart_text: String) -> void:
 	if game_over_label:

--- a/scripts/main/UIController.gd
+++ b/scripts/main/UIController.gd
@@ -95,7 +95,7 @@ func setup_key_ui(key_nodes: Array[Area2D]) -> void:
 		return
 	_key_ui_manager.build_from_keys(key_nodes)
 
-func setup_door_ui(door_nodes: Array[StaticBody2D]) -> void:
+func setup_door_ui(door_nodes: Array) -> void:
 	if _key_ui_manager == null:
 		return
 	_key_ui_manager.build_from_doors(door_nodes)

--- a/scripts/main/level/LevelGenerationService.gd
+++ b/scripts/main/level/LevelGenerationService.gd
@@ -83,7 +83,7 @@ func apply_generation_outcome(binding_result: Dictionary, level_type: int) -> Di
 	main.exit = generated_exit if generated_exit and is_instance_valid(generated_exit) else null
 	var coins: Array[Area2D] = generated_coins if typeof(generated_coins) == TYPE_ARRAY else [] as Array[Area2D]
 	var keys: Array[Area2D] = generated_keys if typeof(generated_keys) == TYPE_ARRAY else [] as Array[Area2D]
-	var doors: Array[StaticBody2D] = generated_doors if typeof(generated_doors) == TYPE_ARRAY else [] as Array[StaticBody2D]
+	var doors: Array = generated_doors if typeof(generated_doors) == TYPE_ARRAY else [] as Array[StaticBody2D]
 	if main.exit:
 		LOGGER.log_generation("Exit generated at %s" % [main.exit.position])
 	else:
@@ -140,7 +140,7 @@ func apply_generation_outcome(binding_result: Dictionary, level_type: int) -> Di
 		"doors": doors
 	}
 
-func _apply_initial_door_state(doors: Array[StaticBody2D]) -> void:
+func _apply_initial_door_state(doors: Array) -> void:
 	if ui_controller == null:
 		return
 	for door in doors:

--- a/scripts/main/level/LevelGenerationService.gd
+++ b/scripts/main/level/LevelGenerationService.gd
@@ -1,0 +1,135 @@
+extends RefCounted
+
+class_name LevelGenerationService
+
+const LOGGER := preload("res://scripts/Logger.gd")
+const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
+const GAME_STATE := preload("res://scripts/GameState.gd")
+
+var main
+var ui_controller
+
+func setup(main_ref, ui_controller_ref) -> void:
+	main = main_ref
+	ui_controller = ui_controller_ref
+
+func calculate_generation_size(level_type: int) -> float:
+	var generation_level_size: float = main.game_state.current_level_size
+	if level_type == GAME_STATE.LevelType.KEYS:
+		generation_level_size = min(
+			generation_level_size + 0.35,
+			main.game_state.max_level_size + 0.25
+		)
+	return generation_level_size
+
+func reset_runtime_state() -> void:
+	main.level_start_time = Time.get_ticks_msec() / 1000.0
+	main.collected_coins = main.previous_coin_count
+	main.exit_active = false
+	main.exit = null
+	main.total_coins = 0
+	main.total_keys = 0
+	main.collected_keys_count = 0
+	main.collected_key_ids.clear()
+	main.game_state.set_state(GAME_STATE.GameStateType.PLAYING)
+	if main.game_state.current_state != GAME_STATE.GameStateType.PLAYING:
+		LOGGER.log_game_mode("Game state corrected to PLAYING before generation")
+		main.game_state.set_state(GAME_STATE.GameStateType.PLAYING)
+
+func determine_generation_flags(level_type: int) -> Dictionary:
+	var generate_obstacles: bool = main.game_state.generate_obstacles
+	var generate_coins: bool = main.game_state.generate_coins
+	if level_type == GAME_STATE.LevelType.KEYS:
+		generate_obstacles = false
+		generate_coins = false
+	elif (
+		level_type == GAME_STATE.LevelType.MAZE
+		or level_type == GAME_STATE.LevelType.MAZE_COINS
+		or level_type == GAME_STATE.LevelType.MAZE_KEYS
+	):
+		generate_obstacles = false
+		generate_coins = false
+	return {
+		"generate_obstacles": generate_obstacles,
+		"generate_coins": generate_coins
+	}
+
+func invoke_level_generator(level_type: int, generation_level_size: float, flags: Dictionary) -> bool:
+	if main.level_generator and is_instance_valid(main.level_generator):
+		main.level_generator.generate_level(
+			generation_level_size,
+			flags.get("generate_obstacles", true),
+			flags.get("generate_coins", true),
+			main.game_state.min_exit_distance_ratio,
+			main.game_state.use_full_map_coverage,
+			main,
+			main.game_state.current_level,
+			main.previous_coin_count,
+			main.player.global_position if main.player else LEVEL_UTILS.PLAYER_START,
+			level_type
+		)
+		return true
+	LOGGER.log_error("LevelGenerator missing when attempting to generate level")
+	return false
+
+func apply_generation_outcome(binding_result: Dictionary, level_type: int) -> Dictionary:
+	var has_spawn_override: bool = bool(binding_result.get("has_spawn_override", false))
+	var spawn_override: Vector2 = binding_result.get("spawn_override", Vector2.ZERO)
+	var generated_exit = binding_result.get("exit")
+	var generated_coins = binding_result.get("coins", [] as Array[Area2D])
+	var generated_keys = binding_result.get("keys", [] as Array[Area2D])
+	main.exit = generated_exit if generated_exit and is_instance_valid(generated_exit) else null
+	var coins: Array[Area2D] = generated_coins if typeof(generated_coins) == TYPE_ARRAY else [] as Array[Area2D]
+	var keys: Array[Area2D] = generated_keys if typeof(generated_keys) == TYPE_ARRAY else [] as Array[Area2D]
+	if main.exit:
+		LOGGER.log_generation("Exit generated at %s" % [main.exit.position])
+	else:
+		LOGGER.log_generation("No exit generated")
+	LOGGER.log_generation("Coins generated: %d" % coins.size())
+	LOGGER.log_generation("Keys generated: %d" % keys.size())
+	if main.timer_manager:
+		var timer_start_position: Vector2 = spawn_override if has_spawn_override else (
+			main.player.global_position if main.player else LEVEL_UTILS.PLAYER_START
+		)
+		var maze_path_length: float = 0.0
+		if main.level_generator and is_instance_valid(main.level_generator):
+			maze_path_length = main.level_generator.get_last_maze_path_length()
+		main.game_time = main.timer_manager.calculate_level_time(
+			main.game_state.current_level,
+			coins,
+			main.exit.position if main.exit else Vector2(),
+			timer_start_position,
+			level_type,
+			maze_path_length
+		)
+	else:
+		main.game_time = 30.0
+	main.total_coins = coins.size()
+	main.collected_coins = 0
+	if main.total_coins == 0:
+		main.previous_coin_count = 0
+	main.total_keys = keys.size()
+	main.collected_keys_count = 0
+	main.collected_key_ids.clear()
+	main.exit_active = main.collected_coins >= main.total_coins
+	if main.timer and is_instance_valid(main.timer):
+		main.timer.wait_time = main.game_time
+		main.timer.stop()
+		main.timer.start()
+	if ui_controller:
+		ui_controller.update_coin_display(main.total_coins, main.collected_coins)
+		ui_controller.setup_key_ui(keys)
+		ui_controller.update_exit_state(main.exit_active, main.exit)
+		ui_controller.update_timer_display(main.game_time)
+		ui_controller.update_level_progress(main.game_state.get_level_progress_text())
+	if has_spawn_override and main.player and is_instance_valid(main.player):
+		main.player.global_position = spawn_override
+		main.player.position = spawn_override
+		main.player.rotation = 0.0
+		LOGGER.log_generation("Level ready: time %.2f, coins %d" % [main.game_time, main.total_coins])
+	else:
+		LOGGER.log_generation("Level ready: time %.2f, coins %d (default spawn)" % [main.game_time, main.total_coins])
+	return {
+		"coins": coins,
+		"keys": keys
+	}

--- a/scripts/main/level/LevelObjectBinder.gd
+++ b/scripts/main/level/LevelObjectBinder.gd
@@ -27,7 +27,7 @@ func bind_from_generator(level_generator) -> Dictionary:
 	var coins: Array[Area2D] = level_generator.get_generated_coins() as Array[Area2D]
 	_connect_coins(coins)
 	result.coins = coins
-	var doors: Array[StaticBody2D] = level_generator.get_generated_doors() as Array[StaticBody2D]
+	var doors: Array = level_generator.get_generated_doors() as Array[StaticBody2D]
 	_connect_doors(doors)
 	result.doors = doors
 	var keys: Array[Area2D] = level_generator.get_generated_keys() as Array[Area2D]
@@ -40,7 +40,7 @@ func bind_from_generator(level_generator) -> Dictionary:
 		result.spawn_override = spawn_override_variant
 	return result
 
-func _connect_doors(doors: Array[StaticBody2D]) -> void:
+func _connect_doors(doors: Array) -> void:
 	if main_node == null:
 		return
 	for door in doors:

--- a/scripts/main/level/LevelObjectBinder.gd
+++ b/scripts/main/level/LevelObjectBinder.gd
@@ -1,0 +1,64 @@
+extends RefCounted
+
+class_name LevelObjectBinder
+
+var main_node = null
+var ui_controller = null
+
+func setup(main_ref, ui_controller_ref) -> void:
+	main_node = main_ref
+	ui_controller = ui_controller_ref
+
+func bind_from_generator(level_generator) -> Dictionary:
+	var result := {
+		"exit": null,
+		"coins": [] as Array[Area2D],
+		"keys": [] as Array[Area2D],
+		"spawn_override": Vector2.ZERO,
+		"has_spawn_override": false
+	}
+	if level_generator == null or not is_instance_valid(level_generator):
+		return result
+	var exit_node = level_generator.get_generated_exit()
+	if exit_node and is_instance_valid(exit_node):
+		_connect_exit(exit_node)
+	result.exit = exit_node
+	var coins: Array[Area2D] = level_generator.get_generated_coins() as Array[Area2D]
+	_connect_coins(coins)
+	result.coins = coins
+	var keys: Array[Area2D] = level_generator.get_generated_keys() as Array[Area2D]
+	_connect_keys(keys)
+	result.keys = keys
+	var spawn_override_variant: Variant = level_generator.get_player_spawn_override()
+	var has_spawn_override: bool = typeof(spawn_override_variant) == TYPE_VECTOR2
+	result.has_spawn_override = has_spawn_override
+	if has_spawn_override:
+		result.spawn_override = spawn_override_variant
+	return result
+
+func _connect_exit(exit_node: Node) -> void:
+	if main_node == null or exit_node == null:
+		return
+	var exit_callable: Callable = Callable(main_node, "_on_exit_entered")
+	if exit_node.has_signal("body_entered") and not exit_node.body_entered.is_connected(exit_callable):
+		exit_node.body_entered.connect(exit_callable)
+
+func _connect_coins(coins: Array[Area2D]) -> void:
+	if main_node == null:
+		return
+	for coin in coins:
+		var coin_area: Area2D = coin
+		if coin_area and is_instance_valid(coin_area):
+			var coin_callable: Callable = Callable(main_node, "_on_coin_collected").bind(coin_area)
+			if coin_area.has_signal("body_entered") and not coin_area.body_entered.is_connected(coin_callable):
+				coin_area.body_entered.connect(coin_callable)
+
+func _connect_keys(keys: Array[Area2D]) -> void:
+	if main_node == null:
+		return
+	for key in keys:
+		var key_node: Area2D = key
+		if key_node and is_instance_valid(key_node) and key_node.has_signal("key_collected"):
+			var key_callable: Callable = Callable(main_node, "_on_key_collected")
+			if not key_node.is_connected("key_collected", key_callable):
+				key_node.connect("key_collected", key_callable)

--- a/scripts/main/level/LevelObjectBinder.gd
+++ b/scripts/main/level/LevelObjectBinder.gd
@@ -14,6 +14,7 @@ func bind_from_generator(level_generator) -> Dictionary:
 		"exit": null,
 		"coins": [] as Array[Area2D],
 		"keys": [] as Array[Area2D],
+		"doors": [] as Array[StaticBody2D],
 		"spawn_override": Vector2.ZERO,
 		"has_spawn_override": false
 	}
@@ -26,6 +27,9 @@ func bind_from_generator(level_generator) -> Dictionary:
 	var coins: Array[Area2D] = level_generator.get_generated_coins() as Array[Area2D]
 	_connect_coins(coins)
 	result.coins = coins
+	var doors: Array[StaticBody2D] = level_generator.get_generated_doors() as Array[StaticBody2D]
+	_connect_doors(doors)
+	result.doors = doors
 	var keys: Array[Area2D] = level_generator.get_generated_keys() as Array[Area2D]
 	_connect_keys(keys)
 	result.keys = keys
@@ -35,6 +39,16 @@ func bind_from_generator(level_generator) -> Dictionary:
 	if has_spawn_override:
 		result.spawn_override = spawn_override_variant
 	return result
+
+func _connect_doors(doors: Array[StaticBody2D]) -> void:
+	if main_node == null:
+		return
+	for door in doors:
+		var door_body: StaticBody2D = door
+		if door_body and is_instance_valid(door_body) and door_body.has_signal("door_opened"):
+			var door_callable: Callable = Callable(main_node, "_on_door_opened")
+			if not door_body.is_connected("door_opened", door_callable):
+				door_body.connect("door_opened", door_callable)
 
 func _connect_exit(exit_node: Node) -> void:
 	if main_node == null or exit_node == null:

--- a/scripts/main/ui/KeyUIManager.gd
+++ b/scripts/main/ui/KeyUIManager.gd
@@ -4,47 +4,52 @@ class_name KeyUIManager
 
 const NEUTRAL_COLOR := Color(1, 1, 1, 1)
 const DEFAULT_KEY_COLOR := Color(0.9, 0.9, 0.2, 1.0)
+const DEFAULT_DOOR_COLOR := Color(0.35, 0.35, 0.75, 1.0)
 
 var key_container: Control = null
 var key_status_container: Control = null
+var door_container: Control = null
+var door_status_container: Control = null
 var key_checkbox_nodes: Array[CheckBox] = []
+var door_checkbox_nodes: Array[CheckBox] = []
 var available_key_colors_by_door: Dictionary = {}
 var collected_colors: Array[Color] = []
 var target_collected_count: int = 0
+var door_index_by_id: Dictionary = {}
+var door_colors_by_id: Dictionary = {}
 
-func setup_containers(key_container_ref: Control, key_status_container_ref: Control) -> void:
+func setup_containers(
+	key_container_ref: Control,
+	key_status_container_ref: Control,
+	door_container_ref: Control = null,
+	door_status_container_ref: Control = null
+) -> void:
 	key_container = key_container_ref
 	key_status_container = key_status_container_ref
+	door_container = door_container_ref
+	door_status_container = door_status_container_ref
 	clear()
 
 func clear() -> void:
-	key_checkbox_nodes.clear()
 	available_key_colors_by_door.clear()
 	collected_colors.clear()
 	target_collected_count = 0
-	if key_status_container:
-		for child in key_status_container.get_children():
-			var control_child: Control = child as Control
-			if control_child and is_instance_valid(control_child):
-				control_child.queue_free()
-	if key_container:
-		key_container.visible = false
+	_clear_key_checkboxes()
+	_clear_door_checkboxes()
 
 func build_from_keys(key_nodes: Array[Area2D]) -> void:
-	clear()
+	_clear_key_checkboxes()
+	available_key_colors_by_door.clear()
+	collected_colors.clear()
+	target_collected_count = 0
 	if key_nodes == null:
 		key_nodes = [] as Array[Area2D]
 	var total_keys: int = key_nodes.size()
 	if total_keys <= 0 or key_status_container == null:
+		_update_container_visibility(key_container, key_checkbox_nodes)
 		return
-	if key_container:
-		key_container.visible = true
 	for index in range(total_keys):
-		var checkbox: CheckBox = CheckBox.new()
-		checkbox.disabled = true
-		checkbox.focus_mode = Control.FOCUS_NONE
-		checkbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		checkbox.button_pressed = false
+		var checkbox: CheckBox = _create_status_checkbox()
 		var key_node: Area2D = key_nodes[index] if index < key_nodes.size() else null
 		var color: Color = DEFAULT_KEY_COLOR
 		if key_node and key_node.has_meta("group_color"):
@@ -57,10 +62,42 @@ func build_from_keys(key_nodes: Array[Area2D]) -> void:
 		var door_colors: Array = available_key_colors_by_door.get(door_identifier, [])
 		door_colors.append(color)
 		available_key_colors_by_door[door_identifier] = door_colors
-		checkbox.modulate = NEUTRAL_COLOR
 		key_status_container.add_child(checkbox)
 		key_checkbox_nodes.append(checkbox)
+	_update_container_visibility(key_container, key_checkbox_nodes)
 	_refresh_checkboxes()
+
+func build_from_doors(door_nodes: Array[StaticBody2D]) -> void:
+	_clear_door_checkboxes()
+	if door_nodes == null:
+		door_nodes = [] as Array[StaticBody2D]
+	var total_doors: int = door_nodes.size()
+	if total_doors <= 0 or door_status_container == null:
+		_update_container_visibility(door_container, door_checkbox_nodes)
+		return
+	for index in range(total_doors):
+		var checkbox: CheckBox = _create_status_checkbox()
+		var door_body: StaticBody2D = door_nodes[index] if index < door_nodes.size() else null
+		var door_id: int = index
+		var door_color: Color = DEFAULT_DOOR_COLOR
+		if door_body:
+			if door_body.has_method("get"):
+				var door_id_value = door_body.get("door_id")
+				if door_id_value != null:
+					door_id = int(door_id_value)
+			if door_body.has_method("get_door_color"):
+				door_color = door_body.get_door_color()
+			elif door_body.has_meta("group_color"):
+				door_color = door_body.get_meta("group_color")
+			elif door_body.has_method("get"):
+				var door_color_value = door_body.get("door_color")
+				if typeof(door_color_value) == TYPE_COLOR:
+					door_color = door_color_value
+		door_index_by_id[door_id] = door_checkbox_nodes.size()
+		door_colors_by_id[door_id] = door_color
+		door_status_container.add_child(checkbox)
+		door_checkbox_nodes.append(checkbox)
+	_update_container_visibility(door_container, door_checkbox_nodes)
 
 func update_key_status_display(collected_keys: int) -> void:
 	target_collected_count = clamp(collected_keys, 0, key_checkbox_nodes.size())
@@ -77,6 +114,25 @@ func mark_key_collected(door_id: int) -> void:
 	target_collected_count = min(collected_colors.size(), key_checkbox_nodes.size())
 	_refresh_checkboxes()
 
+func mark_door_opened(door_id: int, door_color: Color) -> void:
+	var target_index: int = int(door_index_by_id.get(door_id, -1))
+	if target_index < 0:
+		if door_status_container == null:
+			return
+		var checkbox: CheckBox = _create_status_checkbox()
+		door_status_container.add_child(checkbox)
+		door_checkbox_nodes.append(checkbox)
+		target_index = door_checkbox_nodes.size() - 1
+		door_index_by_id[door_id] = target_index
+	var checkbox: CheckBox = door_checkbox_nodes[target_index]
+	if checkbox == null or not is_instance_valid(checkbox):
+		return
+	var color_to_use: Color = door_color if typeof(door_color) == TYPE_COLOR else DEFAULT_DOOR_COLOR
+	door_colors_by_id[door_id] = color_to_use
+	checkbox.button_pressed = true
+	checkbox.modulate = color_to_use
+	_update_container_visibility(door_container, door_checkbox_nodes)
+
 func _refresh_checkboxes() -> void:
 	for index in range(key_checkbox_nodes.size()):
 		var checkbox: CheckBox = key_checkbox_nodes[index]
@@ -90,5 +146,37 @@ func _refresh_checkboxes() -> void:
 			checkbox.modulate = collected_color
 		else:
 			checkbox.modulate = NEUTRAL_COLOR
-	if key_container:
-		key_container.visible = key_checkbox_nodes.size() > 0
+	_update_container_visibility(key_container, key_checkbox_nodes)
+
+func _create_status_checkbox() -> CheckBox:
+	var checkbox: CheckBox = CheckBox.new()
+	checkbox.disabled = true
+	checkbox.focus_mode = Control.FOCUS_NONE
+	checkbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	checkbox.button_pressed = false
+	checkbox.modulate = NEUTRAL_COLOR
+	return checkbox
+
+func _clear_key_checkboxes() -> void:
+	if key_status_container:
+		for child in key_status_container.get_children():
+			var control_child: Control = child as Control
+			if control_child and is_instance_valid(control_child):
+				control_child.queue_free()
+	key_checkbox_nodes.clear()
+	_update_container_visibility(key_container, key_checkbox_nodes)
+
+func _clear_door_checkboxes() -> void:
+	if door_status_container:
+		for child in door_status_container.get_children():
+			var control_child: Control = child as Control
+			if control_child and is_instance_valid(control_child):
+				control_child.queue_free()
+	door_checkbox_nodes.clear()
+	door_index_by_id.clear()
+	door_colors_by_id.clear()
+	_update_container_visibility(door_container, door_checkbox_nodes)
+
+func _update_container_visibility(container: Control, nodes: Array) -> void:
+	if container:
+		container.visible = nodes.size() > 0

--- a/scripts/main/ui/KeyUIManager.gd
+++ b/scripts/main/ui/KeyUIManager.gd
@@ -67,7 +67,7 @@ func build_from_keys(key_nodes: Array[Area2D]) -> void:
 	_update_container_visibility(key_container, key_checkbox_nodes)
 	_refresh_checkboxes()
 
-func build_from_doors(door_nodes: Array[StaticBody2D]) -> void:
+func build_from_doors(door_nodes: Array) -> void:
 	_clear_door_checkboxes()
 	if door_nodes == null:
 		door_nodes = [] as Array[StaticBody2D]

--- a/scripts/main/ui/KeyUIManager.gd
+++ b/scripts/main/ui/KeyUIManager.gd
@@ -1,0 +1,110 @@
+extends RefCounted
+
+class_name KeyUIManager
+
+var key_container: Control = null
+var key_status_container: Control = null
+var key_checkbox_nodes: Array[CheckBox] = []
+var key_colors: Array[Color] = []
+var key_door_ids: Array[int] = []
+var collected_key_counts: Dictionary = {}
+var key_slot_counts: Dictionary = {}
+
+func setup_containers(key_container_ref: Control, key_status_container_ref: Control) -> void:
+	key_container = key_container_ref
+	key_status_container = key_status_container_ref
+	clear()
+
+func clear() -> void:
+	key_checkbox_nodes.clear()
+	key_colors.clear()
+	key_door_ids.clear()
+	collected_key_counts.clear()
+	key_slot_counts.clear()
+	if key_status_container:
+		for child in key_status_container.get_children():
+			var control_child: Control = child as Control
+			if control_child and is_instance_valid(control_child):
+				control_child.queue_free()
+	if key_container:
+		key_container.visible = false
+
+func build_from_keys(key_nodes: Array[Area2D]) -> void:
+	clear()
+	if key_nodes == null:
+		key_nodes = [] as Array[Area2D]
+	var total_keys: int = key_nodes.size()
+	if total_keys <= 0 or key_status_container == null:
+		return
+	if key_container:
+		key_container.visible = true
+	for index in range(total_keys):
+		var checkbox: CheckBox = CheckBox.new()
+		checkbox.disabled = true
+		checkbox.focus_mode = Control.FOCUS_NONE
+		checkbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		checkbox.button_pressed = false
+		var key_node: Area2D = key_nodes[index] if index < key_nodes.size() else null
+		var color: Color = Color(0.9, 0.9, 0.2, 1.0)
+		if key_node and key_node.has_meta("group_color"):
+			color = key_node.get_meta("group_color")
+		key_colors.append(color)
+		var door_identifier: int = index
+		if key_node and key_node.has_method("get"):
+			var door_value = key_node.get("door_id")
+			if door_value != null:
+				door_identifier = int(door_value)
+		key_door_ids.append(door_identifier)
+		key_slot_counts[door_identifier] = key_slot_counts.get(door_identifier, 0) + 1
+		checkbox.modulate = color
+		key_status_container.add_child(checkbox)
+		key_checkbox_nodes.append(checkbox)
+	_refresh_checkboxes()
+
+func update_key_status_display(collected_keys: int) -> void:
+	collected_key_counts.clear()
+	var remaining: int = clamp(collected_keys, 0, key_door_ids.size())
+	for door_id in key_door_ids:
+		if remaining <= 0:
+			break
+		var total_slots: int = int(key_slot_counts.get(door_id, 0))
+		if total_slots <= 0:
+			continue
+		var current: int = int(collected_key_counts.get(door_id, 0))
+		if current >= total_slots:
+			continue
+		collected_key_counts[door_id] = current + 1
+		remaining -= 1
+	_refresh_checkboxes()
+
+func mark_key_collected(door_id: int) -> void:
+	var total_slots: int = int(key_slot_counts.get(door_id, 0))
+	if total_slots <= 0:
+		return
+	var collected: int = int(collected_key_counts.get(door_id, 0))
+	if collected >= total_slots:
+		return
+	collected_key_counts[door_id] = collected + 1
+	_refresh_checkboxes()
+
+func _refresh_checkboxes() -> void:
+	var per_door_usage: Dictionary = {}
+	for index in range(key_checkbox_nodes.size()):
+		var checkbox: CheckBox = key_checkbox_nodes[index]
+		if checkbox == null or not is_instance_valid(checkbox):
+			continue
+		var door_identifier: int = key_door_ids[index] if index < key_door_ids.size() else index
+		var collected_total: int = int(collected_key_counts.get(door_identifier, 0))
+		var used: int = int(per_door_usage.get(door_identifier, 0))
+		var is_collected: bool = used < collected_total
+		per_door_usage[door_identifier] = used + 1
+		checkbox.button_pressed = is_collected
+		var base_color: Color = key_colors[index] if index < key_colors.size() else Color(0.9, 0.9, 0.2, 1.0)
+		if is_collected:
+			var highlight: Color = base_color.lightened(0.35)
+			highlight.a = base_color.a
+			checkbox.modulate = highlight
+		else:
+			checkbox.modulate = base_color
+	if key_container:
+		key_container.visible = key_checkbox_nodes.size() > 0

--- a/scripts/main/ui/KeyUIManager.gd
+++ b/scripts/main/ui/KeyUIManager.gd
@@ -2,13 +2,15 @@ extends RefCounted
 
 class_name KeyUIManager
 
+const NEUTRAL_COLOR := Color(1, 1, 1, 1)
+const DEFAULT_KEY_COLOR := Color(0.9, 0.9, 0.2, 1.0)
+
 var key_container: Control = null
 var key_status_container: Control = null
 var key_checkbox_nodes: Array[CheckBox] = []
-var key_colors: Array[Color] = []
-var key_door_ids: Array[int] = []
-var collected_key_counts: Dictionary = {}
-var key_slot_counts: Dictionary = {}
+var available_key_colors_by_door: Dictionary = {}
+var collected_colors: Array[Color] = []
+var target_collected_count: int = 0
 
 func setup_containers(key_container_ref: Control, key_status_container_ref: Control) -> void:
 	key_container = key_container_ref
@@ -17,10 +19,9 @@ func setup_containers(key_container_ref: Control, key_status_container_ref: Cont
 
 func clear() -> void:
 	key_checkbox_nodes.clear()
-	key_colors.clear()
-	key_door_ids.clear()
-	collected_key_counts.clear()
-	key_slot_counts.clear()
+	available_key_colors_by_door.clear()
+	collected_colors.clear()
+	target_collected_count = 0
 	if key_status_container:
 		for child in key_status_container.get_children():
 			var control_child: Control = child as Control
@@ -45,66 +46,49 @@ func build_from_keys(key_nodes: Array[Area2D]) -> void:
 		checkbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		checkbox.button_pressed = false
 		var key_node: Area2D = key_nodes[index] if index < key_nodes.size() else null
-		var color: Color = Color(0.9, 0.9, 0.2, 1.0)
+		var color: Color = DEFAULT_KEY_COLOR
 		if key_node and key_node.has_meta("group_color"):
 			color = key_node.get_meta("group_color")
-		key_colors.append(color)
 		var door_identifier: int = index
 		if key_node and key_node.has_method("get"):
 			var door_value = key_node.get("door_id")
 			if door_value != null:
 				door_identifier = int(door_value)
-		key_door_ids.append(door_identifier)
-		key_slot_counts[door_identifier] = key_slot_counts.get(door_identifier, 0) + 1
-		checkbox.modulate = color
+		var door_colors: Array = available_key_colors_by_door.get(door_identifier, [])
+		door_colors.append(color)
+		available_key_colors_by_door[door_identifier] = door_colors
+		checkbox.modulate = NEUTRAL_COLOR
 		key_status_container.add_child(checkbox)
 		key_checkbox_nodes.append(checkbox)
 	_refresh_checkboxes()
 
 func update_key_status_display(collected_keys: int) -> void:
-	collected_key_counts.clear()
-	var remaining: int = clamp(collected_keys, 0, key_door_ids.size())
-	for door_id in key_door_ids:
-		if remaining <= 0:
-			break
-		var total_slots: int = int(key_slot_counts.get(door_id, 0))
-		if total_slots <= 0:
-			continue
-		var current: int = int(collected_key_counts.get(door_id, 0))
-		if current >= total_slots:
-			continue
-		collected_key_counts[door_id] = current + 1
-		remaining -= 1
+	target_collected_count = clamp(collected_keys, 0, key_checkbox_nodes.size())
 	_refresh_checkboxes()
 
 func mark_key_collected(door_id: int) -> void:
-	var total_slots: int = int(key_slot_counts.get(door_id, 0))
-	if total_slots <= 0:
-		return
-	var collected: int = int(collected_key_counts.get(door_id, 0))
-	if collected >= total_slots:
-		return
-	collected_key_counts[door_id] = collected + 1
+	var color_queue: Array = available_key_colors_by_door.get(door_id, [])
+	var key_color: Color = DEFAULT_KEY_COLOR
+	if color_queue.size() > 0:
+		key_color = color_queue[0]
+		color_queue.remove_at(0)
+		available_key_colors_by_door[door_id] = color_queue
+	collected_colors.append(key_color)
+	target_collected_count = min(collected_colors.size(), key_checkbox_nodes.size())
 	_refresh_checkboxes()
 
 func _refresh_checkboxes() -> void:
-	var per_door_usage: Dictionary = {}
 	for index in range(key_checkbox_nodes.size()):
 		var checkbox: CheckBox = key_checkbox_nodes[index]
 		if checkbox == null or not is_instance_valid(checkbox):
 			continue
-		var door_identifier: int = key_door_ids[index] if index < key_door_ids.size() else index
-		var collected_total: int = int(collected_key_counts.get(door_identifier, 0))
-		var used: int = int(per_door_usage.get(door_identifier, 0))
-		var is_collected: bool = used < collected_total
-		per_door_usage[door_identifier] = used + 1
+		var is_collected: bool = index < target_collected_count
 		checkbox.button_pressed = is_collected
-		var base_color: Color = key_colors[index] if index < key_colors.size() else Color(0.9, 0.9, 0.2, 1.0)
 		if is_collected:
-			var highlight: Color = base_color.lightened(0.35)
-			highlight.a = base_color.a
-			checkbox.modulate = highlight
+			var color_index: int = min(index, collected_colors.size() - 1)
+			var collected_color: Color = collected_colors[color_index] if color_index >= 0 else DEFAULT_KEY_COLOR
+			checkbox.modulate = collected_color
 		else:
-			checkbox.modulate = base_color
+			checkbox.modulate = NEUTRAL_COLOR
 	if key_container:
 		key_container.visible = key_checkbox_nodes.size() > 0

--- a/scripts/timer/TimerBalanceCalculator.gd
+++ b/scripts/timer/TimerBalanceCalculator.gd
@@ -1,0 +1,59 @@
+class_name TimerBalanceCalculator
+extends RefCounted
+
+static func level_multiplier(level: int, preset: Dictionary) -> float:
+	var mult_max: float = float(preset.get("mult_max", 1.0))
+	var mult_min: float = float(preset.get("mult_min", 1.0))
+	var half_life: float = max(float(preset.get("half_life", 1.0)), 0.0001)
+	var decay: float = pow(0.5, float(max(level, 1) - 1) / half_life)
+	return mult_min + (mult_max - mult_min) * decay
+
+static func buffer_cap_sec(level: int, preset: Dictionary) -> float:
+	var start: float = float(preset.get("buf_cap_start", 0.0))
+	var endv: float = float(preset.get("buf_cap_end", start))
+	var half_life: float = max(float(preset.get("cap_half_life", 1.0)), 0.0001)
+	var decay: float = pow(0.5, float(max(level, 1) - 1) / half_life)
+	return endv + (start - endv) * decay
+
+static func target_surplus_sec(level: int) -> float:
+	var t: float = clamp((float(level) - 1.0) / 6.0, 0.0, 1.0)
+	return lerp(6.0, 2.0, t)
+
+static func route_detour_factor(coin_count: int) -> float:
+	var n: float = float(max(coin_count, 0))
+	var detour: float = log(1.0 + n) / log(2.0)
+	return 1.0 + 0.05 * detour
+
+static func level_type_scale(profile: Dictionary, level: int) -> float:
+	var start: float = float(profile.get("scale_start", 1.0))
+	var endv: float = float(profile.get("scale_end", start))
+	var t = clamp((float(level) - 1.0) / 8.0, 0.0, 1.0)
+	return lerp(start, endv, t)
+
+static func maze_overhead(is_maze: bool, profile: Dictionary, maze_path_length: float, player_start: Vector2, exit_pos: Vector2, speed: float) -> Dictionary:
+	if not is_maze:
+		return {"factor": 1.0, "slack": 0.0, "base_path": 0.0}
+	var straight: float = player_start.distance_to(exit_pos)
+	var fallback_factor: float = float(profile.get("maze_fallback_factor", 1.35))
+	var base_path: float = 0.0
+	if straight > 0.0:
+		base_path = straight * fallback_factor
+	if maze_path_length > 0.0:
+		var floor_scale: float = float(profile.get("maze_path_floor", 1.0))
+		base_path = max(maze_path_length, straight * floor_scale)
+		var ratio = clamp(maze_path_length / max(straight, 1.0), 1.0, 4.5)
+		var base_scale: float = float(profile.get("maze_base_scale", 0.6))
+		var factor = 1.0 + (ratio - 1.0) * base_scale
+		var ratio_span: float = max(float(profile.get("maze_ratio_span", 2.5)), 0.5)
+		var ratio_t = clamp((ratio - 1.0) / ratio_span, 0.0, 1.0)
+		var slack_curve: Vector2 = profile.get("maze_slack_curve", Vector2.ZERO)
+		var slack = 0.0
+		if slack_curve != Vector2.ZERO:
+			slack += lerp(slack_curve.x, slack_curve.y, ratio_t)
+		var path_scale: float = float(profile.get("maze_path_scale", 0.8))
+		var path_cap: float = float(profile.get("maze_path_cap", 8.0))
+		var path_bonus = clamp((maze_path_length - straight) / max(speed, 1.0), 0.0, path_cap)
+		slack += path_bonus * path_scale
+		return {"factor": factor, "slack": slack, "base_path": base_path}
+	var fallback_slack: float = float(profile.get("maze_fallback_slack", 5.0))
+	return {"factor": fallback_factor, "slack": fallback_slack, "base_path": base_path}

--- a/scripts/timer/TimerBalanceConfig.gd
+++ b/scripts/timer/TimerBalanceConfig.gd
@@ -1,0 +1,108 @@
+class_name TimerBalanceConfig
+extends RefCounted
+
+const GAME_STATE := preload("res://scripts/GameState.gd")
+
+const DEFAULT_PROFILE := {
+	"scale_start": 1.0,
+	"scale_end": 1.0,
+	"buffer_bias": 0.0,
+	"flat_bonus": 0.0
+}
+
+const DIFFICULTY_PRESETS := {
+	"child": {
+		"mult_max": 1.45, "mult_min": 1.05, "half_life": 3.0,
+		"min_time": 15.0, "speed": 250.0, "per_coin_sec": 0.12, "global_scale": 1.00,
+		"buf_cap_start": 9.0, "buf_cap_end": 3.5, "cap_half_life": 3.0
+	},
+	"regular": {
+		# было 1.35→1.25; cap 10→7, 2.5→1.8
+		"mult_max": 1.25, "mult_min": 1.00, "half_life": 2.3,
+		"min_time": 12.0, "speed": 300.0, "per_coin_sec": 0.06, "global_scale": 0.94,
+		"buf_cap_start": 7.0, "buf_cap_end": 1.8, "cap_half_life": 2.3
+	},
+	"hard": {
+		"mult_max": 1.18, "mult_min": 1.00, "half_life": 2.0,
+		"min_time": 10.0, "speed": 320.0, "per_coin_sec": 0.04, "global_scale": 0.90,
+		"buf_cap_start": 5.5, "buf_cap_end": 1.6, "cap_half_life": 2.0
+	},
+	"challenge": {
+		"mult_max": 1.10, "mult_min": 1.00, "half_life": 1.8,
+		"min_time": 8.0, "speed": 360.0, "per_coin_sec": 0.00, "global_scale": 0.88,
+		"buf_cap_start": 4.0, "buf_cap_end": 1.3, "cap_half_life": 1.8
+	}
+}
+
+const LEVEL_TYPE_TUNING := {
+	GAME_STATE.LevelType.OBSTACLES_COINS: {
+		"scale_start": 0.78,
+		"scale_end": 0.48,
+		"buffer_bias": -0.45,
+		"flat_bonus": -1.8,
+		"route_trim": 0.82,
+		"trim_ramp": 4.0
+	},
+	GAME_STATE.LevelType.MAZE: {
+		"scale_start": 0.95, # Reduced from 1.05
+		"scale_end": 0.75, # Reduced from 0.82
+		"buffer_bias": 0.05, # Reduced from 0.12
+		"flat_bonus": 0.8, # Reduced from 1.6
+		"maze_slack_curve": Vector2(2.5, 5.5), # Reduced from 3.5, 7.5
+		"maze_path_scale": 0.45, # Reduced from 0.55
+		"maze_path_cap": 5.5, # Reduced from 7.0
+		"maze_base_scale": 0.42, # Reduced from 0.52
+		"maze_fallback_slack": 3.0, # Reduced from 4.5
+		"maze_ratio_span": 1.8, # Reduced from 2.0
+		"maze_path_floor": 0.95, # Reduced from 1.05
+		"maze_fallback_factor": 1.12 # Reduced from 1.18
+	},
+	GAME_STATE.LevelType.MAZE_COINS: {
+		"scale_start": 0.98, # Reduced from 1.08
+		"scale_end": 0.78, # Reduced from 0.86
+		"buffer_bias": 0.08, # Reduced from 0.18
+		"flat_bonus": 1.4, # Reduced from 2.2
+		"maze_slack_curve": Vector2(3.0, 6.5), # Reduced from 4.0, 8.5
+		"maze_path_scale": 0.50, # Reduced from 0.60
+		"maze_path_cap": 6.0, # Reduced from 7.5
+		"maze_base_scale": 0.48, # Reduced from 0.58
+		"maze_fallback_slack": 3.5, # Reduced from 5.0
+		"maze_ratio_span": 2.0, # Reduced from 2.2
+		"maze_path_floor": 0.98, # Reduced from 1.08
+		"maze_fallback_factor": 1.15 # Reduced from 1.22
+	},
+	GAME_STATE.LevelType.MAZE_KEYS: {
+		"scale_start": 1.02, # Reduced from 1.12
+		"scale_end": 0.82, # Reduced from 0.90
+		"buffer_bias": 0.14, # Reduced from 0.24
+		"flat_bonus": 2.0, # Reduced from 2.8
+		"maze_slack_curve": Vector2(3.5, 7.5), # Reduced from 4.5, 9.5
+		"maze_path_scale": 0.55, # Reduced from 0.65
+		"maze_path_cap": 6.5, # Reduced from 8.0
+		"maze_base_scale": 0.52, # Reduced from 0.62
+		"maze_fallback_slack": 4.0, # Reduced from 5.5
+		"maze_ratio_span": 2.2, # Reduced from 2.4
+		"maze_path_floor": 1.02, # Reduced from 1.12
+		"maze_fallback_factor": 1.18 # Reduced from 1.28
+	},
+	GAME_STATE.LevelType.KEYS: {
+		"scale_start": 2.7, # x2.5 time multiplier
+		"scale_end": 2.4, # x2.5 time multiplier
+		"buffer_bias": 0.15, # Increased buffer
+		"flat_bonus": 3.0 # Increased flat bonus for no coins
+	}
+}
+
+const BASE_TIME_PER_LEVEL := 22.0
+
+static func has_difficulty(name: StringName) -> bool:
+	return DIFFICULTY_PRESETS.has(name)
+
+static func get_difficulty(name: StringName) -> Dictionary:
+	return DIFFICULTY_PRESETS.get(name, DIFFICULTY_PRESETS["regular"])
+
+static func get_type_profile(level_type: int) -> Dictionary:
+	return LEVEL_TYPE_TUNING.get(level_type, DEFAULT_PROFILE)
+
+static func get_default_profile() -> Dictionary:
+	return DEFAULT_PROFILE.duplicate(true)

--- a/tests/unit/test_level_generation_scripts.gd
+++ b/tests/unit/test_level_generation_scripts.gd
@@ -4,6 +4,7 @@ const LevelNodeFactory = preload("res://scripts/level_generators/LevelNodeFactor
 const ObstacleUtilities = preload("res://scripts/level_generators/ObstacleUtilities.gd")
 const KeyLevelGenerator = preload("res://scripts/level_generators/KeyLevelGenerator.gd")
 const MazeGenerator = preload("res://scripts/level_generators/MazeGenerator.gd")
+const MazeDoorAndKeyPlanner = preload("res://scripts/level_generators/maze/MazeDoorAndKeyPlanner.gd")
 const ObstacleSpawner = preload("res://scripts/ObstacleSpawner.gd")
 const CoinSpawner = preload("res://scripts/CoinSpawner.gd")
 const LevelUtils = preload("res://scripts/LevelUtils.gd")
@@ -89,12 +90,12 @@ func test_key_level_generator_sample_far_points_within_bounds() -> void:
 		assert_true(point.y <= 170.0)
 
 func test_maze_generator_select_key_cells_excludes_special_cells() -> void:
-	var generator := track_object(MazeGenerator.new({}, null)) as MazeGenerator
+	var planner := MazeDoorAndKeyPlanner.new()
 	var reachable := [Vector2i(1, 1), Vector2i(3, 1), Vector2i(5, 1), Vector2i(3, 3)]
 	var taken := []
-	var door_worlds: Array = []
-	var key_world_positions: Array = []
-	var result := generator._select_maze_key_cells(reachable, 2, Vector2.ZERO, 10.0, Vector2i(3, 1), Vector2i(1, 1), Vector2i(7, 7), taken, door_worlds, key_world_positions, Vector2.ZERO, Vector2(70, 70))
+	var door_worlds: Array[Vector2] = []
+	var key_world_positions: Array[Vector2] = []
+	var result: Array = planner.select_key_cells(reachable, 2, Vector2.ZERO, 10.0, Vector2i(3, 1), Vector2i(1, 1), Vector2i(7, 7), taken, door_worlds, key_world_positions, Vector2.ZERO, Vector2(70, 70))
 	assert_eq(result.size(), 2)
 	for cell in result:
 		assert_false(cell == Vector2i(1, 1))

--- a/tests/unit/test_main_systems.gd
+++ b/tests/unit/test_main_systems.gd
@@ -83,11 +83,18 @@ class UIStub:
 	func setup_key_ui(_keys: Array[Area2D]) -> void:
 		pass
 
+	func setup_door_ui(_doors: Array[StaticBody2D]) -> void:
+		pass
+
 	func update_key_status_display(_count: int) -> void:
 		pass
 
 	func mark_key_collected(_door_id: int) -> void:
 		pass
+
+	func mark_door_opened(_door_id: int, _door_color: Color) -> void:
+		pass
+
 class StatisticsLoggerStub:
 	extends RefCounted
 
@@ -189,7 +196,9 @@ func test_ui_controller_coin_and_key_updates() -> void:
 	var menu := track_node(Button.new())
 	var key_container := track_node(Control.new())
 	var key_status := track_node(Control.new())
-	controller.setup(main, timer_label, coin_label, level_label, game_over, win_label, restart, menu, key_container, key_status)
+	var door_container := track_node(Control.new())
+	var door_status := track_node(Control.new())
+	controller.setup(main, timer_label, coin_label, level_label, game_over, win_label, restart, menu, key_container, key_status, door_container, door_status)
 	controller.update_coin_display(0, 0)
 	assert_false(coin_label.visible)
 	assert_eq(coin_label.text, "")
@@ -217,7 +226,9 @@ func test_ui_controller_updates_exit_visual_state() -> void:
 	var menu := track_node(Button.new())
 	var key_container := track_node(Control.new())
 	var key_status := track_node(Control.new())
-	controller.setup(main, timer_label, coin_label, level_label, game_over, win_label, restart, menu, key_container, key_status)
+	var door_container := track_node(Control.new())
+	var door_status := track_node(Control.new())
+	controller.setup(main, timer_label, coin_label, level_label, game_over, win_label, restart, menu, key_container, key_status, door_container, door_status)
 	var exit := track_node(Area2D.new())
 	var body := track_node(ColorRect.new())
 	body.name = "ExitBody"


### PR DESCRIPTION
## Summary
- extract maze layout building, door/key planning, and coin placement into dedicated helper scripts used by `MazeGenerator`
- delegate key-level door spacing and key placement to a reusable planner inside `KeyLevelGenerator`
- update level generation unit tests to exercise the new maze planner helpers directly

## Testing
- ./tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0d40a7014832387467821be8feb3b