### PR TITLE
Add complex maze game modes with off-path item placement

### DIFF
--- a/scripts/GameState.gd
+++ b/scripts/GameState.gd
@@ -5,7 +5,7 @@ const GameLogger = preload("res://scripts/Logger.gd")
 
 # Game state management
 enum GameStateType {PLAYING, WON, LOST}
-enum LevelType {OBSTACLES_COINS, KEYS, MAZE, MAZE_COINS, MAZE_KEYS, RANDOM, CHALLENGE}
+enum LevelType {OBSTACLES_COINS, KEYS, MAZE, MAZE_COINS, MAZE_KEYS, MAZE_COMPLEX, MAZE_COMPLEX_COINS, MAZE_COMPLEX_KEYS, RANDOM, CHALLENGE}
 var current_state = GameStateType.PLAYING
 
 # Progressive level scaling
@@ -142,8 +142,18 @@ func _refresh_level_type(force_new: bool = false):
 	if previous_type != current_level_type:
 		GameLogger.log_game_mode("Current level type set to %s" % _get_level_type_label(current_level_type))
 
+
 func _pick_random_level_type() -> LevelType:
-	var options: Array = [LevelType.OBSTACLES_COINS, LevelType.KEYS, LevelType.MAZE, LevelType.MAZE_COINS, LevelType.MAZE_KEYS]
+	var options: Array = [
+		LevelType.OBSTACLES_COINS,
+		LevelType.KEYS,
+		LevelType.MAZE,
+		LevelType.MAZE_COINS,
+		LevelType.MAZE_KEYS,
+		LevelType.MAZE_COMPLEX,
+		LevelType.MAZE_COMPLEX_COINS,
+		LevelType.MAZE_COMPLEX_KEYS
+	]
 	if options.is_empty():
 		return LevelType.OBSTACLES_COINS
 	return options[randi() % options.size()]
@@ -160,6 +170,12 @@ func _get_level_type_label(level_type: LevelType) -> String:
 			return "Maze + Coins"
 		LevelType.MAZE_KEYS:
 			return "Maze + Keys"
+		LevelType.MAZE_COMPLEX:
+			return "Maze complex"
+		LevelType.MAZE_COMPLEX_COINS:
+			return "Maze complex + Coins"
+		LevelType.MAZE_COMPLEX_KEYS:
+			return "Maze complex + Keys"
 		LevelType.RANDOM:
 			return "Random"
 		LevelType.CHALLENGE:
@@ -167,7 +183,16 @@ func _get_level_type_label(level_type: LevelType) -> String:
 	return str(level_type)
 
 func _generate_challenge_sequence() -> void:
-	var base: Array = [LevelType.OBSTACLES_COINS, LevelType.KEYS, LevelType.MAZE, LevelType.MAZE_COINS, LevelType.MAZE_KEYS]
+	var base: Array = [
+		LevelType.OBSTACLES_COINS,
+		LevelType.KEYS,
+		LevelType.MAZE,
+		LevelType.MAZE_COINS,
+		LevelType.MAZE_KEYS,
+		LevelType.MAZE_COMPLEX,
+		LevelType.MAZE_COMPLEX_COINS,
+		LevelType.MAZE_COMPLEX_KEYS
+	]
 	base.shuffle()
 	var sequence: Array = []
 	for item in base:
@@ -182,3 +207,4 @@ func _generate_challenge_sequence() -> void:
 	while sequence.size() < 7:
 		sequence.append(base[(sequence.size() + attempts) % base.size()])
 	challenge_sequence = sequence
+

--- a/scripts/LevelGenerator.gd
+++ b/scripts/LevelGenerator.gd
@@ -69,6 +69,12 @@ func generate_level(level_size := 1.0, generate_obstacles := true, generate_coin
 			maze_generator.generate_maze_level(true, main_scene, player_start_position)
 		GAME_STATE.LevelType.MAZE_KEYS:
 			maze_generator.generate_maze_keys_level(main_scene, level, player_start_position)
+		GAME_STATE.LevelType.MAZE_COMPLEX:
+			maze_generator.generate_complex_maze_level(false, main_scene, player_start_position)
+		GAME_STATE.LevelType.MAZE_COMPLEX_COINS:
+			maze_generator.generate_complex_maze_level(true, main_scene, player_start_position)
+		GAME_STATE.LevelType.MAZE_COMPLEX_KEYS:
+			maze_generator.generate_complex_maze_keys_level(main_scene, level, player_start_position)
 		_:
 			_generate_standard_level(level_size, generate_obstacles, generate_coins, min_exit_distance_ratio, use_full_map_coverage, main_scene, level, preserved_coin_count, player_start_position)
 	return 0

--- a/scripts/MainMenu.gd
+++ b/scripts/MainMenu.gd
@@ -17,6 +17,9 @@ var level_type_options = [
 	{"name": "Maze", "type": GameState.LevelType.MAZE},
 	{"name": "Maze + Coins", "type": GameState.LevelType.MAZE_COINS},
 	{"name": "Maze + Keys", "type": GameState.LevelType.MAZE_KEYS},
+	{"name": "Maze complex", "type": GameState.LevelType.MAZE_COMPLEX},
+	{"name": "Maze complex + Coins", "type": GameState.LevelType.MAZE_COMPLEX_COINS},
+	{"name": "Maze complex + Keys", "type": GameState.LevelType.MAZE_COMPLEX_KEYS},
 	{"name": "Random", "type": GameState.LevelType.RANDOM},
 ]
 var current_level_type_index = 0

--- a/scripts/level_generators/MazeGenerator.gd
+++ b/scripts/level_generators/MazeGenerator.gd
@@ -9,12 +9,14 @@ const PLAYER_COLLISION_SIZE := 32.0
 const BLACK_SHADOW_COLOR := Color(0.0, 0.0, 0.0, 1.0)
 
 const MAZE_LAYOUT_BUILDER := preload("res://scripts/level_generators/maze/MazeLayoutBuilder.gd")
+const COMPLEX_MAZE_LAYOUT_BUILDER := preload("res://scripts/level_generators/maze/ComplexMazeLayoutBuilder.gd")
 const MAZE_DOOR_PLANNER := preload("res://scripts/level_generators/maze/MazeDoorAndKeyPlanner.gd")
 const MAZE_COIN_DISTRIBUTOR := preload("res://scripts/level_generators/maze/MazeCoinDistributor.gd")
 const MAZE_DEBUG_LOGGER := preload("res://scripts/level_generators/maze/MazeDebugLogger.gd")
 
 var context
 var _layout_builder
+var _complex_layout_builder
 var _door_planner
 var _coin_distributor
 var _debug_logger
@@ -22,9 +24,155 @@ var _debug_logger
 func _init(level_context, _obstacle_helper):
 	context = level_context
 	_layout_builder = MAZE_LAYOUT_BUILDER.new(context)
+	_complex_layout_builder = COMPLEX_MAZE_LAYOUT_BUILDER.new(context)
 	_door_planner = MAZE_DOOR_PLANNER.new()
 	_coin_distributor = MAZE_COIN_DISTRIBUTOR.new(context)
 	_debug_logger = MAZE_DEBUG_LOGGER.new()
+
+func generate_complex_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
+	var layout := _build_complex_layout(main_scene, player_start_position)
+	if layout.is_empty():
+		return
+	var grid: Array = layout.get("grid", [])
+	var cols: int = layout.get("cols", 0)
+	var rows: int = layout.get("rows", 0)
+	var cell_size: float = layout.get("cell_size", 0.0)
+	var maze_offset: Vector2 = layout.get("maze_offset", Vector2.ZERO)
+	var start_cell: Vector2i = layout.get("start_cell", Vector2i.ZERO)
+	var farthest_data = MAZE_UTILS.find_farthest_cell(grid, start_cell, cols, rows)
+	var exit_cell: Vector2i = layout.get("exit_cell", farthest_data["cell"])
+	var path: Array = MAZE_UTILS.reconstruct_maze_path(grid, start_cell, exit_cell, cols, rows)
+	var path_steps: int = max(path.size() - 1, int(farthest_data.get("distance", 0)))
+	context.last_maze_path_length = float(max(path_steps, 1)) * cell_size
+	var exit_position = MAZE_UTILS.maze_cell_to_world(exit_cell, maze_offset, cell_size)
+	context.exit_spawner.clear_exit()
+	context.exit_spawner.create_exit_at(exit_position, main_scene)
+	var exit_node = context.exit_spawner.get_exit()
+	if exit_node:
+		context.exit_pos = exit_node.position
+	context.coins.clear()
+	if include_coins:
+		_coin_distributor.populate_with_offpath_ratio(grid, start_cell, exit_cell, maze_offset, cell_size, main_scene, 0.5)
+
+func generate_complex_maze_keys_level(main_scene, level: int, player_start_position: Vector2) -> void:
+	var layout := _build_complex_layout(main_scene, player_start_position)
+	if layout.is_empty():
+		return
+	var grid: Array = layout.get("grid", [])
+	var cols: int = layout.get("cols", 0)
+	var rows: int = layout.get("rows", 0)
+	var cell_size: float = layout.get("cell_size", 0.0)
+	var maze_offset: Vector2 = layout.get("maze_offset", Vector2.ZERO)
+	var start_cell: Vector2i = layout.get("start_cell", Vector2i.ZERO)
+	var start_world: Vector2 = layout.get("start_world", Vector2.ZERO)
+	var farthest_data = MAZE_UTILS.find_farthest_cell(grid, start_cell, cols, rows)
+	var exit_cell: Vector2i = layout.get("exit_cell", farthest_data["cell"])
+	var path: Array = MAZE_UTILS.reconstruct_maze_path(grid, start_cell, exit_cell, cols, rows)
+	var path_steps: int = max(path.size() - 1, int(farthest_data.get("distance", 0)))
+	context.last_maze_path_length = float(max(path_steps, 1)) * cell_size
+	var path_index := {}
+	for i in range(path.size()):
+		var path_cell: Vector2i = path[i]
+		path_index[path_cell] = i
+	context.coins.clear()
+	context.exit_spawner.clear_exit()
+	var exit_position = MAZE_UTILS.maze_cell_to_world(exit_cell, maze_offset, cell_size)
+	context.exit_spawner.create_exit_at(exit_position, main_scene)
+	var exit_node = context.exit_spawner.get_exit()
+	if exit_node:
+		context.exit_pos = exit_node.position
+	var desired_door_count = clamp(2 + int(floor(level / 3.0)), 2, 5)
+	var door_cells: Array = _door_planner.select_door_cells(path, start_cell, exit_cell, maze_offset, cell_size, desired_door_count)
+	if door_cells.is_empty():
+		door_cells.append(exit_cell)
+	else:
+		door_cells.sort_custom(func(a, b):
+			var ia: int = int(path_index.get(a, 0))
+			var ib: int = int(path_index.get(b, 0))
+			return ia < ib)
+	var exit_world = MAZE_UTILS.maze_cell_to_world(exit_cell, maze_offset, cell_size)
+	var door_worlds: Array[Vector2] = []
+	for door_cell in door_cells:
+		door_worlds.append(MAZE_UTILS.maze_cell_to_world(door_cell, maze_offset, cell_size))
+	var key_world_positions: Array[Vector2] = []
+	var taken_cells: Array = []
+	var door_data: Array = []
+	for i in range(door_cells.size()):
+		var door_cell: Vector2i = door_cells[i]
+		var blocked: Array = []
+		for j in range(i, door_cells.size()):
+			blocked.append(door_cells[j])
+		var reachable_cells: Array = _door_planner.collect_reachable_cells_before_door(grid, start_cell, blocked)
+		var keys_target = clamp(1 + int(floor(level / 4.0)) + (i % 2), 1, 4)
+		var key_cells: Array = _door_planner.select_key_cells(
+			reachable_cells,
+			keys_target,
+			maze_offset,
+			cell_size,
+			door_cell,
+			start_cell,
+			exit_cell,
+			taken_cells,
+			door_worlds,
+			key_world_positions,
+			start_world,
+			exit_world
+		)
+		if key_cells.is_empty() and keys_target > 0:
+			var fallback_cell: Vector2i = door_cell
+			var fallback_score: float = -INF
+			var door_world = door_worlds[i]
+			for variant in reachable_cells:
+				var candidate: Vector2i = variant
+				if candidate == start_cell or candidate == exit_cell or candidate == door_cell:
+					continue
+				if taken_cells.has(candidate):
+					continue
+				var world = MAZE_UTILS.maze_cell_to_world(candidate, maze_offset, cell_size)
+				var score = min(world.distance_to(door_world), world.distance_to(start_world))
+				score = min(score, world.distance_to(exit_world))
+				for existing_world in key_world_positions:
+					score = min(score, world.distance_to(existing_world))
+				if score > fallback_score:
+					fallback_score = score
+					fallback_cell = candidate
+			if fallback_cell != door_cell:
+				key_cells.append(fallback_cell)
+				var fallback_world = MAZE_UTILS.maze_cell_to_world(fallback_cell, maze_offset, cell_size)
+				key_world_positions.append(fallback_world)
+		for cell in key_cells:
+			taken_cells.append(cell)
+		var color = context.get_group_color(i)
+		door_data.append({
+			"cell": door_cell,
+			"keys": key_cells,
+			"color": color,
+			"reachable": reachable_cells.duplicate()
+		})
+	var off_path_required = _ensure_complex_keys_off_path(door_data, taken_cells, path, start_cell, exit_cell)
+	var door_index_offset = context.doors.size()
+	for i in range(door_data.size()):
+		var entry: Dictionary = door_data[i]
+		var door_cell: Vector2i = entry.get("cell", exit_cell)
+		var key_cells: Array = entry.get("keys", [])
+		var key_count: int = key_cells.size()
+		var door_color: Color = entry.get("color", context.get_group_color(i))
+		var initially_open: bool = key_count <= 0
+		var door = LEVEL_NODE_FACTORY.create_door_node(door_index_offset + i, key_count, initially_open, cell_size, cell_size, door_color)
+		door.position = maze_offset + Vector2(door_cell.x * cell_size, door_cell.y * cell_size)
+		context.doors.append(door)
+		context.add_generated_node(door, main_scene)
+		if key_count > 0:
+			for cell in key_cells:
+				var key_pos = MAZE_UTILS.maze_cell_to_world(cell, maze_offset, cell_size)
+				var key_node = LEVEL_NODE_FACTORY.create_key_node(context.key_items.size(), door, key_pos, key_count, door_color)
+				context.key_items.append(key_node)
+				context.add_generated_node(key_node, main_scene)
+	var actual_off_path := 0
+	for cell in taken_cells:
+		if not path_index.has(cell):
+			actual_off_path += 1
+	LOGGER.log_generation("Maze complex+Keys placed %d keys (%d off-path, required %d)" % [taken_cells.size(), actual_off_path, off_path_required])
 
 func generate_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
 	var layout := _build_layout(main_scene, player_start_position)
@@ -164,6 +312,85 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 				context.add_generated_node(key_node, main_scene)
 		LOGGER.log_generation("Maze+Keys door %d at %s with %d keys" % [door_index_offset + i, str(door_cell), key_count])
 
+func _ensure_complex_keys_off_path(door_data: Array, taken_cells: Array, path: Array, start_cell: Vector2i, exit_cell: Vector2i) -> int:
+	var path_index := {}
+	for variant in path:
+		var cell: Vector2i = variant
+		path_index[cell] = true
+	var total_keys := 0
+	var off_path := 0
+	for entry in door_data:
+		var keys: Array = entry.get("keys", [])
+		total_keys += keys.size()
+		for key_cell in keys:
+			if not path_index.has(key_cell):
+				off_path += 1
+	if total_keys <= 0:
+		taken_cells.clear()
+		return 0
+	var required := int(ceil(total_keys * 0.5))
+	if off_path < required:
+		var needed := required - off_path
+		var taken_set := {}
+		for entry in door_data:
+			for key_cell in entry.get("keys", []):
+				taken_set[key_cell] = true
+		for i in range(door_data.size()):
+			if needed <= 0:
+				break
+			var entry: Dictionary = door_data[i]
+			var keys: Array = entry.get("keys", [])
+			if keys.is_empty():
+				continue
+			var door_cell: Vector2i = entry.get("cell", start_cell)
+			var reachable: Array = entry.get("reachable", [])
+			var candidates: Array = []
+			for variant in reachable:
+				var candidate: Vector2i = variant
+				if candidate == start_cell or candidate == exit_cell or candidate == door_cell:
+					continue
+				if path_index.has(candidate):
+					continue
+				if taken_set.has(candidate):
+					continue
+				candidates.append(candidate)
+			candidates.shuffle()
+			for key_index in range(keys.size()):
+				if needed <= 0:
+					break
+				var current_cell: Vector2i = keys[key_index]
+				if not path_index.has(current_cell):
+					continue
+				while candidates.size() > 0 and needed > 0:
+					var candidate: Vector2i = candidates.pop_back()
+					if taken_set.has(candidate):
+						continue
+					taken_set.erase(current_cell)
+					keys[key_index] = candidate
+					taken_set[candidate] = true
+					needed -= 1
+					break
+			entry["keys"] = keys
+		taken_cells.clear()
+		off_path = 0
+		for entry in door_data:
+			var keys: Array = entry.get("keys", [])
+			for key_cell in keys:
+				taken_cells.append(key_cell)
+				if not path_index.has(key_cell):
+					off_path += 1
+		return required
+	taken_cells.clear()
+	for entry in door_data:
+		for key_cell in entry.get("keys", []):
+			taken_cells.append(key_cell)
+	return required
+
 func _build_layout(main_scene, player_start_position: Vector2) -> Dictionary:
 	_debug_logger.configure()
 	return _layout_builder.build(main_scene, player_start_position, _debug_logger, PLAYER_COLLISION_SIZE, BLACK_SHADOW_COLOR)
+
+func _build_complex_layout(main_scene, player_start_position: Vector2) -> Dictionary:
+	_debug_logger.configure()
+	return _complex_layout_builder.build(main_scene, player_start_position, _debug_logger, PLAYER_COLLISION_SIZE, BLACK_SHADOW_COLOR)
+

--- a/scripts/level_generators/maze/ComplexMazeLayoutBuilder.gd
+++ b/scripts/level_generators/maze/ComplexMazeLayoutBuilder.gd
@@ -1,0 +1,369 @@
+extends RefCounted
+class_name ComplexMazeLayoutBuilder
+
+const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
+const MAZE_UTILS := preload("res://scripts/level_generators/MazeUtils.gd")
+const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+const MAZE_REACHABILITY_JOB: GDScript = preload("res://scripts/level_generators/MazeReachabilityJob.gd")
+const WALL_COLOR := Color(0.15, 0.18, 0.28, 1)
+
+var _context
+
+var _maze_columns := 0
+var _maze_rows := 0
+var _all_cells: Dictionary = {}
+var _unvisited: Array = []
+var _stack: Array = []
+var _centre_cells: Array = []
+var _start_cell: Cell = null
+
+const LEFT := 1
+const RIGHT := 2
+const UP := 3
+const DOWN := 4
+
+class Cell:
+	var grid_pos: Vector2i
+	var wall_left := true
+	var wall_right := true
+	var wall_up := true
+	var wall_down := true
+
+	func _init(pos: Vector2i):
+		grid_pos = pos
+
+func _init(level_context):
+	_context = level_context
+
+func build(main_scene, player_start_position: Vector2, debug_logger, player_collision_size: float, shadow_color: Color) -> Dictionary:
+	var dims = LEVEL_UTILS.get_scaled_level_dimensions(_context.current_level_size)
+	var level_width: float = float(dims.width)
+	var level_height: float = float(dims.height)
+	var offset = Vector2(dims.offset_x, dims.offset_y)
+	var cell_size = _context.MAZE_BASE_CELL_SIZE
+	var max_grid_cols = int(floor(level_width / cell_size))
+	var max_grid_rows = int(floor(level_height / cell_size))
+	max_grid_cols = max(max_grid_cols | 1, 5)
+	max_grid_rows = max(max_grid_rows | 1, 5)
+	var cell_cols = int((max_grid_cols - 1) / 2)
+	var cell_rows = int((max_grid_rows - 1) / 2)
+	if cell_cols % 2 != 0:
+		cell_cols = max(cell_cols - 1, 2)
+	if cell_rows % 2 != 0:
+		cell_rows = max(cell_rows - 1, 2)
+	cell_cols = max(cell_cols, 2)
+	cell_rows = max(cell_rows, 2)
+	_maze_columns = cell_cols
+	_maze_rows = cell_rows
+	var grid_cols = _maze_columns * 2 + 1
+	var grid_rows = _maze_rows * 2 + 1
+	var maze_width = float(grid_cols) * cell_size
+	var maze_height = float(grid_rows) * cell_size
+	var maze_offset = offset + Vector2((level_width - maze_width) * 0.5, (level_height - maze_height) * 0.5)
+	_init_collections()
+	_create_cells()
+	_create_centre()
+	_run_algorithm()
+	var exit_data = _make_exit()
+	var grid = _build_grid()
+	_spawn_maze_walls(grid, maze_offset, cell_size, main_scene)
+	_fill_unreachable_areas(main_scene, grid, exit_data.start_cell, maze_offset, cell_size, player_collision_size, shadow_color, debug_logger)
+	var start_grid = _cell_to_grid_coords(_start_cell.grid_pos)
+	var start_world = MAZE_UTILS.maze_cell_to_world(start_grid, maze_offset, cell_size)
+	return {
+		"grid": grid,
+		"cols": grid_cols,
+		"rows": grid_rows,
+		"cell_size": cell_size,
+		"maze_offset": maze_offset,
+		"start_cell": start_grid,
+		"start_world": start_world,
+		"exit_cell": exit_data.exit_cell
+	}
+
+func _init_collections() -> void:
+	_all_cells.clear()
+	_unvisited.clear()
+	_stack.clear()
+	_centre_cells.clear()
+	_start_cell = null
+
+func _create_cells() -> void:
+	for x in range(_maze_columns):
+		for y in range(_maze_rows):
+			var cell = Cell.new(Vector2i(x, y))
+			_all_cells[cell.grid_pos] = cell
+			_unvisited.append(cell)
+
+func _create_centre() -> void:
+	var left = int(_maze_columns / 2) - 1
+	var right = int(_maze_columns / 2)
+	var top = int(_maze_rows / 2) - 1
+	var bottom = int(_maze_rows / 2)
+	_centre_cells = [
+		_all_cells.get(Vector2i(left, top)),
+		_all_cells.get(Vector2i(right, top)),
+		_all_cells.get(Vector2i(left, bottom)),
+		_all_cells.get(Vector2i(right, bottom))
+	]
+	for i in range(_centre_cells.size()):
+		if _centre_cells[i] == null:
+			continue
+	for cell in _centre_cells:
+		if cell == null:
+			continue
+		if cell.grid_pos.x == left:
+			_remove_wall(cell, RIGHT)
+		else:
+			_remove_wall(cell, LEFT)
+		if cell.grid_pos.y == top:
+			_remove_wall(cell, DOWN)
+		else:
+			_remove_wall(cell, UP)
+	var indices = [0, 1, 2, 3]
+	indices.shuffle()
+	var start_index = indices.pop_front()
+	_start_cell = _centre_cells[start_index]
+	_current_remove_from_unvisited(_start_cell)
+	for idx in indices:
+		var centre = _centre_cells[idx]
+		_current_remove_from_unvisited(centre)
+
+func _current_remove_from_unvisited(cell: Cell) -> void:
+	if cell == null:
+		return
+	if _unvisited.has(cell):
+		_unvisited.erase(cell)
+
+func _run_algorithm() -> void:
+	if _start_cell == null:
+		return
+	var current = _start_cell
+var wait_target = max(_unvisited.size() - 1, 0)
+	while _unvisited.size() > 0:
+		var neighbours = _get_unvisited_neighbours(current)
+		if neighbours.size() > 0:
+			var next_cell: Cell = neighbours[randi() % neighbours.size()]
+			_stack.append(current)
+			_compare_walls(current, next_cell)
+			current = next_cell
+			_current_remove_from_unvisited(current)
+		else:
+			if _stack.size() <= 0:
+				break
+			current = _stack.pop_back()
+
+func _get_unvisited_neighbours(cell: Cell) -> Array:
+	var result: Array = []
+	if cell == null:
+		return result
+	var pos = cell.grid_pos
+	var offsets = [Vector2i(-1, 0), Vector2i(1, 0), Vector2i(0, -1), Vector2i(0, 1)]
+	for offset in offsets:
+		var candidate_pos = pos + offset
+		if not _all_cells.has(candidate_pos):
+			continue
+		var candidate: Cell = _all_cells[candidate_pos]
+		if candidate == null:
+			continue
+		if _unvisited.has(candidate):
+			result.append(candidate)
+	return result
+
+func _compare_walls(current: Cell, neighbour: Cell) -> void:
+	if current == null or neighbour == null:
+		return
+	if neighbour.grid_pos.x < current.grid_pos.x:
+		_remove_wall(neighbour, RIGHT)
+		_remove_wall(current, LEFT)
+	elif neighbour.grid_pos.x > current.grid_pos.x:
+		_remove_wall(neighbour, LEFT)
+		_remove_wall(current, RIGHT)
+	elif neighbour.grid_pos.y > current.grid_pos.y:
+		_remove_wall(neighbour, UP)
+		_remove_wall(current, DOWN)
+	else:
+		_remove_wall(neighbour, DOWN)
+		_remove_wall(current, UP)
+
+func _remove_wall(cell: Cell, direction: int) -> void:
+	if cell == null:
+		return
+	match direction:
+		LEFT:
+			cell.wall_left = false
+		RIGHT:
+			cell.wall_right = false
+		UP:
+			cell.wall_up = false
+		DOWN:
+			cell.wall_down = false
+
+func _make_exit() -> Dictionary:
+	var edge_cells: Array = []
+	for cell in _all_cells.values():
+		var typed_cell: Cell = cell
+		if typed_cell == null:
+			continue
+		var pos = typed_cell.grid_pos
+		if pos.x == 0 or pos.x == _maze_columns - 1 or pos.y == 0 or pos.y == _maze_rows - 1:
+			edge_cells.append(typed_cell)
+	var distances = _compute_distances(_start_cell)
+	var best_cell: Cell = _start_cell
+	var best_distance := -1
+	for cell in edge_cells:
+		var dist = int(distances.get(cell, -1))
+		if dist > best_distance:
+			best_distance = dist
+			best_cell = cell
+	var exit_cell = _make_exit_in_cell(best_cell)
+	return {
+		"exit_cell": exit_cell,
+		"start_cell": _cell_to_grid_coords(_start_cell.grid_pos)
+	}
+
+func _compute_distances(start_cell: Cell) -> Dictionary:
+	var distances: Dictionary = {}
+	if start_cell == null:
+		return distances
+	var queue: Array = []
+	queue.append(start_cell)
+	distances[start_cell] = 0
+	while queue.size() > 0:
+		var current: Cell = queue.pop_front()
+		var base_distance = int(distances.get(current, 0))
+		for neighbour in _get_connected_neighbours(current):
+			if distances.has(neighbour):
+				continue
+			distances[neighbour] = base_distance + 1
+			queue.append(neighbour)
+	return distances
+
+func _get_connected_neighbours(cell: Cell) -> Array:
+	var result: Array = []
+	if cell == null:
+		return result
+	var pos = cell.grid_pos
+	if pos.x > 0:
+		var left_cell: Cell = _all_cells.get(Vector2i(pos.x - 1, pos.y))
+		if left_cell and not cell.wall_left and not left_cell.wall_right:
+			result.append(left_cell)
+	if pos.x < _maze_columns - 1:
+		var right_cell: Cell = _all_cells.get(Vector2i(pos.x + 1, pos.y))
+		if right_cell and not cell.wall_right and not right_cell.wall_left:
+			result.append(right_cell)
+	if pos.y > 0:
+		var up_cell: Cell = _all_cells.get(Vector2i(pos.x, pos.y - 1))
+		if up_cell and not cell.wall_up and not up_cell.wall_down:
+			result.append(up_cell)
+	if pos.y < _maze_rows - 1:
+		var down_cell: Cell = _all_cells.get(Vector2i(pos.x, pos.y + 1))
+		if down_cell and not cell.wall_down and not down_cell.wall_up:
+			result.append(down_cell)
+	return result
+
+func _make_exit_in_cell(cell: Cell) -> Vector2i:
+	if cell == null:
+		return Vector2i.ZERO
+	var grid_coords = _cell_to_grid_coords(cell.grid_pos)
+	var exit_coords = grid_coords
+	if cell.grid_pos.x == 0:
+		_remove_wall(cell, LEFT)
+		exit_coords = Vector2i(grid_coords.x - 1, grid_coords.y)
+	elif cell.grid_pos.x == _maze_columns - 1:
+		_remove_wall(cell, RIGHT)
+		exit_coords = Vector2i(grid_coords.x + 1, grid_coords.y)
+	elif cell.grid_pos.y == _maze_rows - 1:
+		_remove_wall(cell, DOWN)
+		exit_coords = Vector2i(grid_coords.x, grid_coords.y + 1)
+	else:
+		_remove_wall(cell, UP)
+		exit_coords = Vector2i(grid_coords.x, grid_coords.y - 1)
+	return exit_coords
+
+func _cell_to_grid_coords(pos: Vector2i) -> Vector2i:
+	return Vector2i(pos.x * 2 + 1, pos.y * 2 + 1)
+
+func _build_grid() -> Array:
+	var rows = _maze_rows * 2 + 1
+	var cols = _maze_columns * 2 + 1
+	var grid: Array = []
+	for y in range(rows):
+		var row := []
+		row.resize(cols)
+		for x in range(cols):
+			row[x] = true
+		grid.append(row)
+	for cell in _all_cells.values():
+		var typed: Cell = cell
+		if typed == null:
+			continue
+		var grid_pos = _cell_to_grid_coords(typed.grid_pos)
+		grid[grid_pos.y][grid_pos.x] = false
+		if not typed.wall_left:
+			grid[grid_pos.y][grid_pos.x - 1] = false
+		if not typed.wall_right:
+			grid[grid_pos.y][grid_pos.x + 1] = false
+		if not typed.wall_up:
+			grid[grid_pos.y - 1][grid_pos.x] = false
+		if not typed.wall_down:
+			grid[grid_pos.y + 1][grid_pos.x] = false
+	return grid
+
+func _spawn_maze_walls(grid: Array, offset: Vector2, cell_size: float, main_scene) -> void:
+	var rows = grid.size()
+	if rows <= 0:
+		return
+	var cols = grid[0].size()
+	var thickness = cell_size * _context.MAZE_WALL_SIZE_RATIO
+	var half_thickness = thickness * 0.5
+	for y in range(rows):
+		for x in range(cols):
+			if not grid[y][x]:
+				continue
+			var base := offset + Vector2(x * cell_size, y * cell_size)
+			if y == 0 or not grid[y - 1][x]:
+				var top_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), cell_size, thickness, WALL_COLOR)
+				top_wall.position = base + Vector2(0.0, -half_thickness)
+				_context.maze_walls.append(top_wall)
+				_context.add_generated_node(top_wall, main_scene)
+			if y == rows - 1 or not grid[y + 1][x]:
+				var bottom_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), cell_size, thickness, WALL_COLOR)
+				bottom_wall.position = base + Vector2(0.0, cell_size - half_thickness)
+				_context.maze_walls.append(bottom_wall)
+				_context.add_generated_node(bottom_wall, main_scene)
+			if x == 0 or not grid[y][x - 1]:
+				var left_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), thickness, cell_size, WALL_COLOR)
+				left_wall.position = base + Vector2(-half_thickness, 0.0)
+				_context.maze_walls.append(left_wall)
+				_context.add_generated_node(left_wall, main_scene)
+			if x == cols - 1 or not grid[y][x + 1]:
+				var right_wall = LEVEL_NODE_FACTORY.create_maze_wall_segment(_context.maze_walls.size(), thickness, cell_size, WALL_COLOR)
+				right_wall.position = base + Vector2(cell_size - half_thickness, 0.0)
+				_context.maze_walls.append(right_wall)
+				_context.add_generated_node(right_wall, main_scene)
+
+func _fill_unreachable_areas(main_scene, grid: Array, start_cell: Vector2i, offset: Vector2, cell_size: float, player_collision_size: float, shadow_color: Color, debug_logger) -> void:
+	var job = MAZE_REACHABILITY_JOB.new()
+	var logger_callable := Callable()
+	var debug_enabled: bool = debug_logger and debug_logger.is_enabled()
+	if debug_enabled:
+		logger_callable = Callable(debug_logger, "log")
+	job.setup(
+		_context,
+		main_scene,
+		grid.duplicate(true),
+		start_cell,
+		offset,
+		cell_size,
+		player_collision_size,
+		shadow_color,
+		debug_enabled,
+		logger_callable
+	)
+	if _context and _context is Node:
+		_context.add_child(job)
+	elif main_scene and is_instance_valid(main_scene):
+		main_scene.call_deferred("add_child", job)
+	else:
+		job.queue_free()

--- a/scripts/level_generators/maze/MazeCoinDistributor.gd
+++ b/scripts/level_generators/maze/MazeCoinDistributor.gd
@@ -33,3 +33,69 @@ func populate(grid: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Ve
 		var coin = LEVEL_NODE_FACTORY.create_coin_node(_context.coins.size(), world_pos)
 		_context.coins.append(coin)
 		_context.add_generated_node(coin, main_scene)
+
+func populate_with_offpath_ratio(grid: Array, start_cell: Vector2i, exit_cell: Vector2i, offset: Vector2, cell_size: float, main_scene, min_offpath_ratio: float) -> void:
+	if min_offpath_ratio <= 0.0:
+		populate(grid, start_cell, exit_cell, offset, cell_size, main_scene)
+		return
+	var rows = grid.size()
+	if rows <= 0:
+		return
+	var cols = grid[0].size()
+	var path: Array = MAZE_UTILS.reconstruct_maze_path(grid, start_cell, exit_cell, cols, rows)
+	var path_index := {}
+	for variant in path:
+		var cell: Vector2i = variant
+		path_index[cell] = true
+	var on_path: Array = []
+	var off_path: Array = []
+	for y in range(rows):
+		for x in range(cols):
+			if grid[y][x]:
+				continue
+			var cell = Vector2i(x, y)
+			if cell == start_cell or cell == exit_cell:
+				continue
+			if (abs(cell.x - start_cell.x) + abs(cell.y - start_cell.y)) < 3:
+				continue
+			if path_index.has(cell):
+				on_path.append(cell)
+			else:
+				off_path.append(cell)
+	off_path.shuffle()
+	on_path.shuffle()
+	var total_candidates = on_path.size() + off_path.size()
+	if total_candidates <= 0:
+		return
+	var desired = clamp(int(total_candidates / 8.0), 5, 20)
+	if desired <= 0:
+		return
+	var required_off_path = int(ceil(desired * max(min_offpath_ratio, 0.0)))
+	var coins: Array = []
+	var used := {}
+	var off_index := 0
+	while off_index < off_path.size() and coins.size() < required_off_path:
+		var cell = off_path[off_index]
+		coins.append(cell)
+		used[cell] = true
+		off_index += 1
+	var remaining_candidates: Array = []
+	for i in range(off_index, off_path.size()):
+		var cell = off_path[i]
+		if not used.has(cell):
+			remaining_candidates.append(cell)
+	for cell in on_path:
+		if not used.has(cell):
+			remaining_candidates.append(cell)
+	remaining_candidates.shuffle()
+	for candidate in remaining_candidates:
+		if coins.size() >= desired:
+			break
+		coins.append(candidate)
+		used[candidate] = true
+	for cell in coins:
+		var world_pos = MAZE_UTILS.maze_cell_to_world(cell, offset, cell_size)
+		var coin = LEVEL_NODE_FACTORY.create_coin_node(_context.coins.size(), world_pos)
+		_context.coins.append(coin)
+		_context.add_generated_node(coin, main_scene)
+

--- a/tests/unit/test_level_generator.gd
+++ b/tests/unit/test_level_generator.gd
@@ -18,6 +18,9 @@ class MazeGeneratorStub extends RefCounted:
 	var last_spawn := Vector2.ZERO
 	var keys_call_count := 0
 	var last_key_level := 0
+	var complex_include_coins := false
+	var complex_keys_call_count := 0
+	var last_complex_level := 0
 
 	func generate_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
 		last_include_coins = include_coins
@@ -28,6 +31,17 @@ class MazeGeneratorStub extends RefCounted:
 		keys_call_count += 1
 		last_scene = main_scene
 		last_key_level = level
+		last_spawn = player_start_position
+
+	func generate_complex_maze_level(include_coins: bool, main_scene, player_start_position: Vector2) -> void:
+		complex_include_coins = include_coins
+		last_scene = main_scene
+		last_spawn = player_start_position
+
+	func generate_complex_maze_keys_level(main_scene, level: int, player_start_position: Vector2) -> void:
+		complex_keys_call_count += 1
+		last_scene = main_scene
+		last_complex_level = level
 		last_spawn = player_start_position
 
 class KeyGeneratorStub extends RefCounted:
@@ -93,6 +107,18 @@ func test_generate_level_dispatches_to_branch_generators() -> void:
 	_dispatch_generate(generator, 5, Vector2.ZERO, GameState.LevelType.MAZE_KEYS)
 	assert_eq(maze_stub.keys_call_count, 1)
 	assert_eq(maze_stub.last_key_level, 5)
+
+	_dispatch_generate(generator, 2, Vector2(7, 7), GameState.LevelType.MAZE_COMPLEX)
+	assert_false(maze_stub.complex_include_coins)
+	assert_vector_near(maze_stub.last_spawn, Vector2(7, 7), 0.0001)
+
+	_dispatch_generate(generator, 2, Vector2(8, 9), GameState.LevelType.MAZE_COMPLEX_COINS)
+	assert_true(maze_stub.complex_include_coins)
+	assert_vector_near(maze_stub.last_spawn, Vector2(8, 9), 0.0001)
+
+	_dispatch_generate(generator, 4, Vector2(3, 1), GameState.LevelType.MAZE_COMPLEX_KEYS)
+	assert_eq(maze_stub.complex_keys_call_count, 1)
+	assert_eq(maze_stub.last_complex_level, 4)
 
 func test_clear_existing_objects_resets_state_and_notifies_spawners() -> void:
 	var generator := track_node(LevelGenerator.new())


### PR DESCRIPTION
## Summary
- add Maze complex, Maze complex + Coins, and Maze complex + Keys level types with menu options and random selection support
- implement a complex maze layout builder and generator routines that reuse the legacy maze logic and ensure coins/keys include off-path placements
- extend tests to cover the new dispatch branches for complex maze modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e256c9bb708323979cab2bb081bf84