### PR TITLE
Ensure key modes always spawn blocking doors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Select the desired level template in the main menu. Available options:
 | Level Type | Description |
 |------------|-------------|
 | **Obstacles + Coins** | Classic mode with random obstacles, coin placement, and an exit. |
-| **Keys** | Sequential, color-coded doors guard the exit. Obstacles populate each zone but clear around doorways and spawn, and keys appear before the door they unlock. |
+| **Keys** | Nested square arenas create multi-layer patrol routes. Each wall can host matching, color-coded doors that block progress until you collect the perimeter keys seeded before them. Obstacles populate each zone while clearing space around doorways and spawn. |
 | **Maze** | Generates a procedural maze and places the exit at one of the farthest reachable cells from the spawn point. |
 | **Maze + Coins** | Same maze generation as above, with coins scattered along reachable corridors. |
 | **Maze + Keys** | Maze layout with a locked door near the exit. Collect the matching keys along the solution path to clear the door and finish. |
@@ -57,7 +57,7 @@ Coins spawned by the standard generator are validated with a pathfinder to guara
 
 Key levels place doors across the arena. Locked doors require their assigned keys; each key is guaranteed to be reachable before the door it unlocks. Doors and keys now share matching colors to signal which collectibles unlock which barrier. Each door tracks how many keys remain, clears nearby obstacles for a smooth approach, and illuminates (disabling its collision) once its keys are collected to reveal the path toward the exit.
 
-Key levels also sprinkle obstacles throughout each gated segment to keep movement interesting while carving safe corridors near doors, spawn points, and recently placed keys.
+The dedicated **KEYS** mode now builds concentric square rings with consistent wall thickness so traversal requires walking the perimeter of each layer. Door planners can attach a second barrier to the same wall when there is enough space, and the door spawner keeps keys pinned to the surrounding walls while respecting obstacle spacing. Maze-based key modes continue to scatter doors along the solution path and now always spawn the matching keys so every barrier blocks progress until its key is collected.
 
 Automated tests cover the door planner's spacing and obstacle avoidance guarantees along with the HUD's dynamic key and door indicators so future tweaks can detect regressions quickly (`tests/unit/test_level_generation_scripts.gd`, `tests/unit/test_main_systems.gd`).
 

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -5,189 +5,77 @@ class_name KeyLevelGenerator
 const LOGGER := preload("res://scripts/Logger.gd")
 const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
 const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
-const KEY_DOOR_PLANNER := preload("res://scripts/level_generators/key/KeyDoorPlanner.gd")
-
-const BARRIER_COLOR := Color(0.18, 0.21, 0.32, 1)
-const DOOR_EDGE_MARGIN := 45.0
-const MIN_DOOR_GAP := 140.0
+const KEY_PLACEMENT := preload("res://scripts/level_generators/key/KeyPlacementUtils.gd")
+const KEY_RING_LAYOUT := preload("res://scripts/level_generators/key/KeyRingLayoutPlanner.gd")
+const KEY_RING_BARRIERS := preload("res://scripts/level_generators/key/KeyRingBarrierBuilder.gd")
+const KEY_RING_DOORS := preload("res://scripts/level_generators/key/KeyRingDoorSpawner.gd")
 
 var context
 var obstacle_utils
-var _door_planner
+var _layout_planner
+var _barrier_builder
+var _door_spawner
 
 func _init(level_context, obstacle_helper):
 	context = level_context
 	obstacle_utils = obstacle_helper
-	_door_planner = KEY_DOOR_PLANNER.new(context)
+	_layout_planner = KEY_RING_LAYOUT.new(context)
+	_barrier_builder = KEY_RING_BARRIERS.new(context)
+	_door_spawner = KEY_RING_DOORS.new(context, obstacle_utils)
 
 func generate(main_scene, level: int, player_start_position: Vector2) -> void:
 	var dims = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
 	var level_width: float = float(dims.width)
 	var level_height: float = float(dims.height)
 	var offset = Vector2(dims.offset_x, dims.offset_y)
-
-	var door_count = clamp(3 + int(floor(level / 2.0)), 3, 7)
-	var player_body_size = 32.0 # Player body is 32x32
-	var min_door_spacing = player_body_size * 4.0
-	var min_spacing = max(min(level_width, level_height) * 0.22 + 160.0, min_door_spacing)
-	var door_centers: Array = _sample_far_points(door_count, offset, level_width, level_height, min_spacing)
-
-	var door_layouts: Array = []
-	var closed_indices: Array = []
-	for i in range(door_count):
-		var center: Vector2 = door_centers[i]
-		var door_width = randf_range(44.0, 64.0)
-		center.x = clamp(center.x, offset.x + door_width * 0.5 + DOOR_EDGE_MARGIN, offset.x + level_width - door_width * 0.5 - DOOR_EDGE_MARGIN)
-		var gap_height = clamp(level_height * randf_range(0.32, 0.45), 170.0, level_height - 140.0)
-		var door_top = clamp(center.y - gap_height * 0.5, offset.y + 50.0, offset.y + level_height - gap_height - 50.0)
-		var door_bottom = door_top + gap_height
-		var initially_open = false
-		if i % 4 == 3 and randf() < 0.25:
-			initially_open = true
-		var extra_key = 0
-		if i % 3 == 1:
-			extra_key = 1
-		var keys_needed = clamp(1 + int(floor(level / 3.0)) + extra_key, 1, 4)
-		if initially_open:
-			keys_needed = 0
-		else:
-			closed_indices.append(i)
-		door_layouts.append({
-			"index": i,
-			"center_x": center.x,
-			"center_y": center.y,
-			"door_top": door_top,
-			"door_bottom": door_bottom,
-			"door_width": door_width,
-			"gap_height": gap_height,
-			"keys_needed": keys_needed,
-			"initially_open": initially_open,
-			"color": context.get_group_color(i)
-		})
-
-	if closed_indices.is_empty() and door_layouts.size() > 0:
-		var layout: Dictionary = door_layouts[0]
-		layout["initially_open"] = false
-		layout["keys_needed"] = max(int(layout.get("keys_needed", 0)), 1)
-		door_layouts[0] = layout
-		closed_indices.append(0)
-
-	_enforce_door_spacing(door_layouts, offset, level_width, max(MIN_DOOR_GAP, min_door_spacing))
-
-	var spawn_y = clamp(player_start_position.y, offset.y + 90.0, offset.y + level_height - 90.0)
-	var spawn_override = Vector2(offset.x + 90.0, spawn_y)
-	_generate_key_level_obstacles(context.current_level_size, main_scene, level, offset, level_width, level_height, door_layouts, spawn_override)
-
+	var layout = _layout_planner.create_layout(offset, level_width, level_height, level)
+	var rings: Array = layout.get("rings", [])
+	if rings.is_empty():
+		_generate_legacy_key_level(main_scene, level, player_start_position, offset, level_width, level_height)
+		return
 	context.exit_spawner.clear_exit()
 	context.coins.clear()
-	var used_key_positions: Array = []
-	var key_positions: Array = []
-	var exit_position = Vector2(offset.x + level_width - 140.0, offset.y + level_height * randf_range(0.35, 0.65))
-
-	var door_index_offset = context.doors.size()
-	for layout_index in range(door_layouts.size()):
-		var layout: Dictionary = door_layouts[layout_index]
-		var center_x = float(layout.get("center_x", offset.x))
-		var door_top = float(layout.get("door_top", offset.y))
-		var door_bottom = float(layout.get("door_bottom", door_top + 200.0))
-		var door_width = float(layout.get("door_width", 48.0))
-		var gap_height = float(layout.get("gap_height", door_bottom - door_top))
-		var group_color: Color = layout.get("color", context.get_group_color(layout_index))
-		var initially_open: bool = layout.get("initially_open", false)
-		var keys_needed = int(layout.get("keys_needed", 0))
-		if initially_open and keys_needed > 0:
-			keys_needed = 0
-		var door = LEVEL_NODE_FACTORY.create_door_node(door_index_offset + layout_index, keys_needed, initially_open, gap_height, door_width, group_color)
-		door.position = Vector2(center_x - door_width * 0.5, door_top)
-		context.doors.append(door)
-		context.add_generated_node(door, main_scene)
-
-		var top_segment_height = max(door_top - offset.y, 0.0)
-		if top_segment_height > 0.0:
-			var top_segment = LEVEL_NODE_FACTORY.create_barrier_segment(context.key_barriers.size(), door_width, top_segment_height, BARRIER_COLOR)
-			top_segment.position = Vector2(center_x - door_width * 0.5, offset.y)
-			context.key_barriers.append(top_segment)
-			context.add_generated_node(top_segment, main_scene)
-
-		var bottom_segment_height = max(offset.y + level_height - door_bottom, 0.0)
-		if bottom_segment_height > 0.0:
-			var bottom_segment = LEVEL_NODE_FACTORY.create_barrier_segment(context.key_barriers.size(), door_width, bottom_segment_height, BARRIER_COLOR)
-			bottom_segment.position = Vector2(center_x - door_width * 0.5, door_bottom)
-			context.key_barriers.append(bottom_segment)
-			context.add_generated_node(bottom_segment, main_scene)
-
-		var door_center = Vector2(center_x, (door_top + door_bottom) * 0.5)
-		var assigned_keys: Array = []
-		if keys_needed > 0:
-			assigned_keys = _pick_keys_for_door(door_center, door_width, keys_needed, offset, level_width, level_height, spawn_override, exit_position, used_key_positions)
-		var actual_keys = assigned_keys.size()
-		if actual_keys != keys_needed:
-			door.required_keys = actual_keys
-		if actual_keys <= 0:
-			door.initially_open = true
-			door.required_keys = 0
-		var key_requirement = max(door.required_keys, 1)
-		for key_pos in assigned_keys:
-			key_positions.append(key_pos)
-			var key_node = LEVEL_NODE_FACTORY.create_key_node(context.key_items.size(), door, key_pos, key_requirement, group_color)
-			context.key_items.append(key_node)
-			context.add_generated_node(key_node, main_scene)
-		LOGGER.log_generation("Keys level door %d at %.1f, %.1f requires %d keys" % [door_index_offset + layout_index, center_x, door_center.y, door.required_keys])
-
-	if not key_positions.is_empty():
-		obstacle_utils.clear_near_points(key_positions, 90.0)
-
+	var spawn_override: Vector2 = layout.get("spawn", Vector2(offset.x + 90.0, offset.y + level_height * 0.5))
+	_generate_key_level_obstacles(context.current_level_size, main_scene, level, rings, spawn_override)
+	var exit_position: Vector2 = layout.get("exit", Vector2(offset.x + level_width - 160.0, offset.y + level_height * 0.5))
+	_barrier_builder.spawn(rings, main_scene)
+	_door_spawner.spawn(rings, main_scene)
 	context.exit_spawner.create_exit_at(exit_position, main_scene)
 	var exit_node = context.exit_spawner.get_exit()
 	if exit_node:
 		context.exit_pos = exit_node.position
 	obstacle_utils.clear_around_position(context.exit_pos, 110.0)
-
 	context.set_player_spawn_override(spawn_override)
 
-
-func _generate_key_level_obstacles(level_size: float, main_scene, level: int, offset: Vector2, _level_width: float, level_height: float, door_layouts: Array, spawn_override: Vector2) -> void:
+func _generate_key_level_obstacles(level_size: float, _main_scene, level: int, rings: Array, spawn_override: Vector2) -> void:
 	if context.obstacle_spawner == null or not is_instance_valid(context.obstacle_spawner):
 		LOGGER.log_error("ObstacleSpawner unavailable for key level")
 		return
-
-	context.obstacles = context.obstacle_spawner.generate_obstacles(level_size, true, main_scene, level)
+	context.obstacles = context.obstacle_spawner.generate_obstacles(level_size, true, _main_scene, level)
 	if context.obstacles.is_empty():
 		return
-
-	var door_margin = 70.0
-	var clearance_rects: Array = []
-	for layout in door_layouts:
-		if typeof(layout) != TYPE_DICTIONARY:
-			continue
-		var center_x = float(layout.get("center_x", offset.x))
-		var door_width = float(layout.get("door_width", 48.0))
-		var rect_half = door_width * 0.5 + door_margin
-		var rect_position = Vector2(center_x - rect_half, offset.y)
-		var rect_size = Vector2(door_width + door_margin * 2.0, level_height)
-		clearance_rects.append(Rect2(rect_position, rect_size))
-
+	var clearance_rects: Array = _layout_planner.build_clearance_rects(rings)
 	if not clearance_rects.is_empty():
 		obstacle_utils.clear_in_rects(clearance_rects)
-
 	if spawn_override != Vector2.ZERO:
 		obstacle_utils.clear_around_position(spawn_override, 140.0)
 
-func _sample_far_points(count: int, offset: Vector2, level_width: float, level_height: float, min_distance: float) -> Array:
-	return _door_planner.sample_far_points(count, offset, level_width, level_height, min_distance)
-
-func _enforce_door_spacing(door_layouts: Array, offset: Vector2, level_width: float, min_gap: float) -> void:
-	_door_planner.enforce_spacing(door_layouts, offset, level_width, min_gap, DOOR_EDGE_MARGIN)
-
-func _pick_keys_for_door(
-	door_center: Vector2,
-	door_width: float,
-	keys_needed: int,
-	offset: Vector2,
-	level_width: float,
-	level_height: float,
-	spawn_override: Vector2,
-	exit_position: Vector2,
-	used_positions: Array
-) -> Array:
-	return _door_planner.pick_keys_for_door(door_center, door_width, keys_needed, offset, level_width, level_height, spawn_override, exit_position, used_positions)
+func _generate_legacy_key_level(main_scene, level: int, player_start_position: Vector2, offset: Vector2, level_width: float, level_height: float) -> void:
+	var spawn_y = clamp(player_start_position.y, offset.y + 90.0, offset.y + level_height - 90.0)
+	var spawn_override = Vector2(offset.x + 90.0, spawn_y)
+	_generate_key_level_obstacles(context.current_level_size, main_scene, level, [], spawn_override)
+	context.exit_spawner.clear_exit()
+	context.coins.clear()
+	var fallback_points := KEY_PLACEMENT.sample_far_points(3, offset, level_width, level_height, 220.0)
+	for point in fallback_points:
+		var door = LEVEL_NODE_FACTORY.create_door_node(context.doors.size(), 0, true, 140.0, 48.0, context.get_group_color(context.doors.size()))
+		door.position = Vector2(point.x - 24.0, point.y - 70.0)
+		context.doors.append(door)
+		context.add_generated_node(door, main_scene)
+	var exit_position = Vector2(offset.x + level_width - 140.0, offset.y + level_height * 0.5)
+	context.exit_spawner.create_exit_at(exit_position, main_scene)
+	var exit_node = context.exit_spawner.get_exit()
+	if exit_node:
+		context.exit_pos = exit_node.position
+	obstacle_utils.clear_around_position(context.exit_pos, 110.0)
+	context.set_player_spawn_override(spawn_override)

--- a/scripts/level_generators/MazeGenerator.gd
+++ b/scripts/level_generators/MazeGenerator.gd
@@ -137,15 +137,20 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 				key_cells.append(fallback_cell)
 				var fallback_world = MAZE_UTILS.maze_cell_to_world(fallback_cell, maze_offset, cell_size)
 				key_world_positions.append(fallback_world)
-		if key_cells.is_empty():
-			for path_cell in path:
-				if path_cell == start_cell or path_cell == exit_cell or path_cell == door_cell:
-					continue
-				if taken_cells.has(path_cell):
-					continue
-				key_cells.append(path_cell)
-				key_world_positions.append(MAZE_UTILS.maze_cell_to_world(path_cell, maze_offset, cell_size))
-				break
+			if key_cells.is_empty():
+				var door_path_index: int = int(path_index.get(door_cell, path.size()))
+				for idx in range(door_path_index):
+					var path_cell: Vector2i = path[idx]
+					if path_cell == start_cell or path_cell == exit_cell or path_cell == door_cell:
+						continue
+					if taken_cells.has(path_cell):
+						continue
+					key_cells.append(path_cell)
+					key_world_positions.append(MAZE_UTILS.maze_cell_to_world(path_cell, maze_offset, cell_size))
+					break
+				if key_cells.is_empty() and not taken_cells.has(start_cell):
+					key_cells.append(start_cell)
+					key_world_positions.append(start_world)
 		for cell in key_cells:
 			taken_cells.append(cell)
 		var color = context.get_group_color(i)

--- a/scripts/level_generators/MazeGenerator.gd
+++ b/scripts/level_generators/MazeGenerator.gd
@@ -87,6 +87,7 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 			var ib: int = int(path_index.get(b, 0))
 			return ia < ib)
 	var exit_world = MAZE_UTILS.maze_cell_to_world(exit_cell, maze_offset, cell_size)
+	context.set_player_spawn_override(start_world)
 	var door_worlds: Array[Vector2] = []
 	for door_cell in door_cells:
 		door_worlds.append(MAZE_UTILS.maze_cell_to_world(door_cell, maze_offset, cell_size))
@@ -136,6 +137,15 @@ func generate_maze_keys_level(main_scene, level: int, player_start_position: Vec
 				key_cells.append(fallback_cell)
 				var fallback_world = MAZE_UTILS.maze_cell_to_world(fallback_cell, maze_offset, cell_size)
 				key_world_positions.append(fallback_world)
+		if key_cells.is_empty():
+			for path_cell in path:
+				if path_cell == start_cell or path_cell == exit_cell or path_cell == door_cell:
+					continue
+				if taken_cells.has(path_cell):
+					continue
+				key_cells.append(path_cell)
+				key_world_positions.append(MAZE_UTILS.maze_cell_to_world(path_cell, maze_offset, cell_size))
+				break
 		for cell in key_cells:
 			taken_cells.append(cell)
 		var color = context.get_group_color(i)

--- a/scripts/level_generators/key/KeyRingBarrierBuilder.gd
+++ b/scripts/level_generators/key/KeyRingBarrierBuilder.gd
@@ -1,0 +1,89 @@
+extends RefCounted
+
+class_name KeyRingBarrierBuilder
+
+const SETTINGS := preload("res://scripts/level_generators/key/KeyRingSettings.gd")
+const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+
+var _context
+
+func _init(level_context):
+	_context = level_context
+
+func spawn(rings: Array, main_scene) -> void:
+	for ring in rings:
+		if typeof(ring) != TYPE_DICTIONARY:
+			continue
+		for wall in range(4):
+			var door_spans: Array = []
+			for door_layout in ring.get("doors", []):
+				if typeof(door_layout) != TYPE_DICTIONARY:
+					continue
+				if int(door_layout.get("wall", -1)) == wall:
+					door_spans.append(door_layout)
+			_spawn_for_wall(ring, wall, door_spans, main_scene)
+
+func _spawn_for_wall(ring: Dictionary, wall: int, door_spans: Array, main_scene) -> void:
+	var wall_thickness: float = float(ring.get("wall_thickness", SETTINGS.WALL_THICKNESS))
+	var left: float = float(ring.get("left", 0.0))
+	var right: float = float(ring.get("right", 0.0))
+	var top: float = float(ring.get("top", 0.0))
+	var bottom: float = float(ring.get("bottom", 0.0))
+	var sorted = door_spans.duplicate()
+	sorted.sort_custom(func(a, b):
+		if wall == 0 or wall == 2:
+			return float(a.get("position", Vector2.ZERO).x) < float(b.get("position", Vector2.ZERO).x)
+		return float(a.get("position", Vector2.ZERO).y) < float(b.get("position", Vector2.ZERO).y))
+	match wall:
+		0:
+			var cursor = left
+			var wall_y = top - wall_thickness
+			for span in sorted:
+				var door_pos: Vector2 = span.get("position", Vector2.ZERO)
+				var door_width: float = float(span.get("size", Vector2.ZERO).x)
+				if door_pos.x > cursor:
+					_spawn_segment(Vector2(cursor, wall_y), door_pos.x - cursor, wall_thickness, main_scene)
+				cursor = max(cursor, door_pos.x + door_width)
+			if right - cursor > 1.0:
+				_spawn_segment(Vector2(cursor, wall_y), right - cursor, wall_thickness, main_scene)
+		1:
+			var cursor_y = top
+			var wall_x = right - wall_thickness
+			for span_right in sorted:
+				var door_pos_right: Vector2 = span_right.get("position", Vector2.ZERO)
+				var door_height: float = float(span_right.get("size", Vector2.ZERO).y)
+				if door_pos_right.y > cursor_y:
+					_spawn_segment(Vector2(wall_x, cursor_y), wall_thickness, door_pos_right.y - cursor_y, main_scene)
+				cursor_y = max(cursor_y, door_pos_right.y + door_height)
+			if bottom - cursor_y > 1.0:
+				_spawn_segment(Vector2(wall_x, cursor_y), wall_thickness, bottom - cursor_y, main_scene)
+		2:
+			var bottom_cursor = left
+			var bottom_y = bottom - wall_thickness
+			for span_bottom in sorted:
+				var bottom_pos: Vector2 = span_bottom.get("position", Vector2.ZERO)
+				var bottom_width: float = float(span_bottom.get("size", Vector2.ZERO).x)
+				if bottom_pos.x > bottom_cursor:
+					_spawn_segment(Vector2(bottom_cursor, bottom_y), bottom_pos.x - bottom_cursor, wall_thickness, main_scene)
+				bottom_cursor = max(bottom_cursor, bottom_pos.x + bottom_width)
+			if right - bottom_cursor > 1.0:
+				_spawn_segment(Vector2(bottom_cursor, bottom_y), right - bottom_cursor, wall_thickness, main_scene)
+		3:
+			var left_cursor = top
+			var left_x = left
+			for span_left in sorted:
+				var left_pos: Vector2 = span_left.get("position", Vector2.ZERO)
+				var left_height: float = float(span_left.get("size", Vector2.ZERO).y)
+				if left_pos.y > left_cursor:
+					_spawn_segment(Vector2(left_x, left_cursor), wall_thickness, left_pos.y - left_cursor, main_scene)
+				left_cursor = max(left_cursor, left_pos.y + left_height)
+			if bottom - left_cursor > 1.0:
+				_spawn_segment(Vector2(left_x, left_cursor), wall_thickness, bottom - left_cursor, main_scene)
+
+func _spawn_segment(position: Vector2, width: float, height: float, main_scene) -> void:
+	if width <= 0.0 or height <= 0.0:
+		return
+	var barrier = LEVEL_NODE_FACTORY.create_barrier_segment(_context.key_barriers.size(), width, height, SETTINGS.BARRIER_COLOR)
+	barrier.position = position
+	_context.key_barriers.append(barrier)
+	_context.add_generated_node(barrier, main_scene)

--- a/scripts/level_generators/key/KeyRingDoorSpawner.gd
+++ b/scripts/level_generators/key/KeyRingDoorSpawner.gd
@@ -1,0 +1,198 @@
+extends RefCounted
+
+class_name KeyRingDoorSpawner
+
+const SETTINGS := preload("res://scripts/level_generators/key/KeyRingSettings.gd")
+const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+const KEY_PLACEMENT := preload("res://scripts/level_generators/key/KeyPlacementUtils.gd")
+
+var _context
+var _obstacle_utils
+
+func _init(level_context, obstacle_helper):
+	_context = level_context
+	_obstacle_utils = obstacle_helper
+
+func spawn(rings: Array, main_scene) -> void:
+	var used_key_positions: Array = []
+	for ring in rings:
+		if typeof(ring) != TYPE_DICTIONARY:
+			continue
+		var doors: Array = ring.get("doors", [])
+		for door_index in range(doors.size()):
+			var layout: Dictionary = doors[door_index]
+			var size: Vector2 = layout.get("size", Vector2(SETTINGS.WALL_THICKNESS, SETTINGS.WALL_THICKNESS))
+			var door = LEVEL_NODE_FACTORY.create_door_node(int(layout.get("index", 0)), int(layout.get("keys_needed", 0)), layout.get("initially_open", false), size.y, size.x, layout.get("color", Color.WHITE))
+			door.position = layout.get("position", Vector2.ZERO)
+			_context.doors.append(door)
+			_context.add_generated_node(door, main_scene)
+			layout["node"] = door
+			doors[door_index] = layout
+			_place_keys(ring, layout, used_key_positions, main_scene)
+		ring["doors"] = doors
+
+func _place_keys(ring: Dictionary, layout: Dictionary, used_key_positions: Array, main_scene) -> void:
+	var door: StaticBody2D = layout.get("node", null)
+	if door == null:
+		return
+	var keys_needed = int(layout.get("keys_needed", 0))
+	if keys_needed <= 0:
+		door.initially_open = true
+		door.required_keys = 0
+		return
+	var key_positions: Array = _perimeter_positions(ring, layout, keys_needed, used_key_positions)
+	if key_positions.is_empty():
+		door.initially_open = true
+		door.required_keys = 0
+		return
+	var actual_keys = key_positions.size()
+	if actual_keys != keys_needed:
+		door.required_keys = actual_keys
+	else:
+		door.required_keys = keys_needed
+	door.initially_open = false
+	var key_requirement = max(door.required_keys, 1)
+	for pos in key_positions:
+		used_key_positions.append(pos)
+		var key_node = LEVEL_NODE_FACTORY.create_key_node(_context.key_items.size(), door, pos, key_requirement, layout.get("color", Color.WHITE))
+		_context.key_items.append(key_node)
+		_context.add_generated_node(key_node, main_scene)
+		_obstacle_utils.clear_around_position(pos, 85.0)
+
+func _perimeter_positions(ring: Dictionary, layout: Dictionary, keys_needed: int, used_key_positions: Array) -> Array:
+	var positions: Array = []
+	var inner_margin: float = float(ring.get("inner_margin", SETTINGS.WALL_THICKNESS + SETTINGS.KEY_WALL_OFFSET))
+	var left: float = float(ring.get("left", 0.0)) + inner_margin
+	var right: float = float(ring.get("right", 0.0)) - inner_margin
+	var top: float = float(ring.get("top", 0.0)) + inner_margin
+	var bottom: float = float(ring.get("bottom", 0.0)) - inner_margin
+	if right <= left or bottom <= top:
+		return positions
+	var door_wall = int(layout.get("wall", 0))
+	var walls_order = [_opposite_wall(door_wall), (door_wall + 1) % 4, (door_wall + 3) % 4, door_wall]
+	var fractions = [0.22, 0.5, 0.78]
+	for wall in walls_order:
+		if positions.size() >= keys_needed:
+			break
+		for candidate in _wall_candidates(ring, wall, inner_margin, fractions, layout):
+			if positions.size() >= keys_needed:
+				break
+			if not _is_candidate_valid(candidate, used_key_positions, positions):
+				continue
+			if KEY_PLACEMENT.is_blocked_by_obstacle(candidate, _context.obstacles):
+				continue
+			positions.append(candidate)
+	if positions.size() < keys_needed:
+		for candidate in _wall_candidates(ring, door_wall, inner_margin, [0.12, 0.88], layout):
+			if positions.size() >= keys_needed:
+				break
+			if not _is_candidate_valid(candidate, used_key_positions, positions):
+				continue
+			if KEY_PLACEMENT.is_blocked_by_obstacle(candidate, _context.obstacles):
+				continue
+			positions.append(candidate)
+	if positions.size() < keys_needed:
+		var opposite = _opposite_wall(door_wall)
+		for candidate in _wall_candidates(ring, opposite, inner_margin, [0.15, 0.85], layout):
+			if positions.size() >= keys_needed:
+				break
+			if not _is_candidate_valid(candidate, used_key_positions, positions):
+				continue
+			if KEY_PLACEMENT.is_blocked_by_obstacle(candidate, _context.obstacles):
+				continue
+			positions.append(candidate)
+	if positions.is_empty():
+		var fallback = _door_fallback_position(ring, layout)
+		if fallback != null and not KEY_PLACEMENT.is_blocked_by_obstacle(fallback, _context.obstacles):
+			positions.append(fallback)
+	return positions
+
+func _wall_candidates(ring: Dictionary, wall: int, inner_margin: float, fractions: Array, layout: Dictionary) -> Array:
+	var positions: Array = []
+	var left: float = float(ring.get("left", 0.0))
+	var right: float = float(ring.get("right", 0.0))
+	var top: float = float(ring.get("top", 0.0))
+	var bottom: float = float(ring.get("bottom", 0.0))
+	var door_wall = int(layout.get("wall", -1))
+	var door_pos: Vector2 = layout.get("position", Vector2.ZERO)
+	var door_size: Vector2 = layout.get("size", Vector2.ZERO)
+	if wall == 0:
+		var start_x = left + inner_margin
+		var end_x = right - inner_margin
+		var y = top + inner_margin
+		for fraction in fractions:
+			var x = lerp(start_x, end_x, clamp(fraction, 0.05, 0.95))
+			if door_wall == wall:
+				var door_left = door_pos.x
+				var door_right = door_pos.x + door_size.x
+				if x >= door_left - SETTINGS.KEY_SEPARATION * 0.5 and x <= door_right + SETTINGS.KEY_SEPARATION * 0.5:
+					continue
+			positions.append(Vector2(x, y))
+	elif wall == 1:
+		var start_y = top + inner_margin
+		var end_y = bottom - inner_margin
+		var x_right = right - inner_margin
+		for fraction_right in fractions:
+			var y_right = lerp(start_y, end_y, clamp(fraction_right, 0.05, 0.95))
+			if door_wall == wall:
+				var door_top = door_pos.y
+				var door_bottom = door_pos.y + door_size.y
+				if y_right >= door_top - SETTINGS.KEY_SEPARATION * 0.5 and y_right <= door_bottom + SETTINGS.KEY_SEPARATION * 0.5:
+					continue
+			positions.append(Vector2(x_right, y_right))
+	elif wall == 2:
+		var start_x_bottom = left + inner_margin
+		var end_x_bottom = right - inner_margin
+		var y_bottom = bottom - inner_margin
+		for fraction_bottom in fractions:
+			var x_bottom = lerp(start_x_bottom, end_x_bottom, clamp(fraction_bottom, 0.05, 0.95))
+			if door_wall == wall:
+				var door_left_bottom = door_pos.x
+				var door_right_bottom = door_pos.x + door_size.x
+				if x_bottom >= door_left_bottom - SETTINGS.KEY_SEPARATION * 0.5 and x_bottom <= door_right_bottom + SETTINGS.KEY_SEPARATION * 0.5:
+					continue
+			positions.append(Vector2(x_bottom, y_bottom))
+	elif wall == 3:
+		var start_y_left = top + inner_margin
+		var end_y_left = bottom - inner_margin
+		var x_left = left + inner_margin
+		for fraction_left in fractions:
+			var y_left = lerp(start_y_left, end_y_left, clamp(fraction_left, 0.05, 0.95))
+			if door_wall == wall:
+				var door_top_left = door_pos.y
+				var door_bottom_left = door_pos.y + door_size.y
+				if y_left >= door_top_left - SETTINGS.KEY_SEPARATION * 0.5 and y_left <= door_bottom_left + SETTINGS.KEY_SEPARATION * 0.5:
+					continue
+			positions.append(Vector2(x_left, y_left))
+	return positions
+
+func _door_fallback_position(ring: Dictionary, layout: Dictionary):
+	var wall = int(layout.get("wall", -1))
+	var inner_margin: float = float(ring.get("inner_margin", SETTINGS.WALL_THICKNESS + SETTINGS.KEY_WALL_OFFSET))
+	var left: float = float(ring.get("left", 0.0))
+	var right: float = float(ring.get("right", 0.0))
+	var top: float = float(ring.get("top", 0.0))
+	var bottom: float = float(ring.get("bottom", 0.0))
+	var center: Vector2 = layout.get("center", layout.get("position", Vector2.ZERO))
+	match wall:
+		0:
+			return Vector2(center.x, top + inner_margin)
+		1:
+			return Vector2(right - inner_margin, center.y)
+		2:
+			return Vector2(center.x, bottom - inner_margin)
+		3:
+			return Vector2(left + inner_margin, center.y)
+	return null
+
+func _is_candidate_valid(candidate: Vector2, used_key_positions: Array, pending: Array) -> bool:
+	for pos in used_key_positions:
+		if pos.distance_to(candidate) < SETTINGS.KEY_SEPARATION:
+			return false
+	for queued in pending:
+		if queued.distance_to(candidate) < SETTINGS.KEY_SEPARATION:
+			return false
+	return true
+
+func _opposite_wall(wall: int) -> int:
+	return (wall + 2) % 4

--- a/scripts/level_generators/key/KeyRingLayoutPlanner.gd
+++ b/scripts/level_generators/key/KeyRingLayoutPlanner.gd
@@ -1,0 +1,214 @@
+extends RefCounted
+
+class_name KeyRingLayoutPlanner
+
+const SETTINGS := preload("res://scripts/level_generators/key/KeyRingSettings.gd")
+
+var _context
+
+func _init(level_context):
+	_context = level_context
+
+func create_layout(offset: Vector2, level_width: float, level_height: float, level: int) -> Dictionary:
+	var result := {
+		"rings": [],
+		"spawn": Vector2.ZERO,
+		"exit": Vector2(offset.x + level_width * 0.5, offset.y + level_height * 0.5)
+	}
+	var rings := _build_rings(offset, level_width, level_height, level)
+	if rings.size() <= 1:
+		return result
+	_plan_ring_doors(rings, level)
+	result["rings"] = rings
+	result["spawn"] = _compute_spawn(offset, rings)
+	result["exit"] = _compute_exit(rings)
+	return result
+
+func build_clearance_rects(rings: Array) -> Array:
+	var rects: Array = []
+	for ring in rings:
+		if typeof(ring) != TYPE_DICTIONARY:
+			continue
+		for rect in _build_ring_clearance_rects(ring):
+			rects.append(rect)
+	return rects
+
+func _build_rings(offset: Vector2, level_width: float, level_height: float, level: int) -> Array:
+	var center = Vector2(offset.x + level_width * 0.5, offset.y + level_height * 0.5)
+	var min_dimension: float = min(level_width, level_height)
+	var outer_half: float = min_dimension * 0.5 - SETTINGS.RING_OUTER_MARGIN
+	if outer_half <= SETTINGS.MIN_INNER_HALF:
+		return []
+	var desired_rings = clamp(3 + int(floor(level / 4.0)), 2, 5)
+	var available_space: float = max(outer_half - SETTINGS.MIN_INNER_HALF, 0.0)
+	var max_rings_by_spacing = int(floor(available_space / SETTINGS.MIN_RING_SPACING)) + 1
+	desired_rings = clamp(desired_rings, 2, max(max_rings_by_spacing, 2))
+	var step = max((outer_half - SETTINGS.MIN_INNER_HALF) / float(max(desired_rings - 1, 1)), SETTINGS.MIN_RING_SPACING * 0.5)
+	var min_spacing = min(step, SETTINGS.MIN_RING_SPACING)
+	var rings: Array = []
+	var current_half: float = outer_half
+	for i in range(desired_rings):
+		if i > 0:
+			var required_remaining = SETTINGS.MIN_INNER_HALF + float(desired_rings - i - 1) * min_spacing
+			current_half = max(current_half - step, required_remaining)
+		if i > 0 and rings.size() > 0:
+			var prev_half: float = float(rings[i - 1].get("half", outer_half))
+			if prev_half - current_half < min_spacing:
+				current_half = prev_half - min_spacing
+			current_half = max(current_half, SETTINGS.MIN_INNER_HALF)
+		if current_half <= SETTINGS.MIN_INNER_HALF * 0.75:
+			break
+		var ring := {
+			"index": i,
+			"half": current_half,
+			"left": center.x - current_half,
+			"right": center.x + current_half,
+			"top": center.y - current_half,
+			"bottom": center.y + current_half,
+			"center": center,
+			"wall_thickness": SETTINGS.WALL_THICKNESS,
+			"inner_margin": SETTINGS.WALL_THICKNESS + SETTINGS.KEY_WALL_OFFSET,
+			"doors": []
+		}
+		ring["width"] = float(ring["right"]) - float(ring["left"])
+		ring["height"] = float(ring["bottom"]) - float(ring["top"])
+		ring["usable_width"] = max(float(ring["width"]) - 2.0 * float(ring["inner_margin"]), 60.0)
+		ring["usable_height"] = max(float(ring["height"]) - 2.0 * float(ring["inner_margin"]), 60.0)
+		rings.append(ring)
+	return rings
+
+func _compute_spawn(offset: Vector2, rings: Array) -> Vector2:
+	if rings.is_empty():
+		return Vector2.ZERO
+	var outer_ring: Dictionary = rings[0]
+	var center: Vector2 = outer_ring.get("center", Vector2.ZERO)
+	var spawn_y = clamp(center.y, float(outer_ring.get("top", center.y)) + 120.0, float(outer_ring.get("bottom", center.y)) - 120.0)
+	var spawn_x = max(offset.x + 80.0, float(outer_ring.get("left", center.x)) - 200.0)
+	return Vector2(spawn_x, spawn_y)
+
+func _compute_exit(rings: Array) -> Vector2:
+	var inner_ring: Dictionary = rings[rings.size() - 1]
+	var center: Vector2 = inner_ring.get("center", Vector2.ZERO)
+	return Vector2(center.x, center.y)
+
+func _build_ring_clearance_rects(ring: Dictionary) -> Array:
+	var rects: Array = []
+	var wall_thickness: float = float(ring.get("wall_thickness", SETTINGS.WALL_THICKNESS))
+	var inner_margin: float = float(ring.get("inner_margin", SETTINGS.WALL_THICKNESS + SETTINGS.KEY_WALL_OFFSET))
+	var left: float = float(ring.get("left", 0.0))
+	var right: float = float(ring.get("right", 0.0))
+	var top: float = float(ring.get("top", 0.0))
+	var bottom: float = float(ring.get("bottom", 0.0))
+	var horizontal_span: float = right - left
+	var vertical_span: float = bottom - top
+	var vertical_depth: float = wall_thickness + inner_margin
+	var horizontal_depth: float = wall_thickness + inner_margin
+	rects.append(Rect2(Vector2(left - wall_thickness, top - wall_thickness), Vector2(horizontal_span + wall_thickness * 2.0, vertical_depth)))
+	rects.append(Rect2(Vector2(left - wall_thickness, bottom - inner_margin), Vector2(horizontal_span + wall_thickness * 2.0, vertical_depth)))
+	rects.append(Rect2(Vector2(left - wall_thickness, top - wall_thickness), Vector2(horizontal_depth, vertical_span + wall_thickness * 2.0)))
+	rects.append(Rect2(Vector2(right - inner_margin, top - wall_thickness), Vector2(horizontal_depth, vertical_span + wall_thickness * 2.0)))
+	return rects
+
+func _plan_ring_doors(rings: Array, level: int) -> void:
+	var wall_sequence = [1, 2, 3, 0]
+	var door_index = _context.doors.size()
+	for ring_index in range(rings.size()):
+		var ring: Dictionary = rings[ring_index]
+		var wall = wall_sequence[ring_index % wall_sequence.size()]
+		var color: Color = _context.get_group_color(ring_index)
+		var keys_needed = clamp(1 + int(floor(level / 4.0)) + ring_index, 1, 5)
+		var capacity = _ring_key_capacity(ring)
+		keys_needed = min(keys_needed, capacity)
+		var doors_for_ring: Array = []
+		var primary = _create_door_layout(ring, wall, randf_range(0.3, 0.7), keys_needed, color, door_index)
+		if primary:
+			doors_for_ring.append(primary)
+			door_index += 1
+			if _can_add_second_door(ring, wall) and randf() < SETTINGS.SECOND_DOOR_PROBABILITY:
+				var secondary_fraction = 0.72 if float(primary.get("fraction", 0.5)) < 0.5 else 0.28
+				var secondary = _create_door_layout(ring, wall, secondary_fraction, keys_needed, color, door_index)
+				if secondary:
+					doors_for_ring.append(secondary)
+					door_index += 1
+		if doors_for_ring.is_empty():
+			continue
+		ring["doors"] = doors_for_ring
+		rings[ring_index] = ring
+
+func _ring_key_capacity(ring: Dictionary) -> int:
+	var usable_width: float = max(float(ring.get("usable_width", 0.0)), 0.0)
+	var usable_height: float = max(float(ring.get("usable_height", 0.0)), 0.0)
+	var perimeter: float = (usable_width + usable_height) * 2.0
+	var spacing: float = max(SETTINGS.KEY_SEPARATION * 0.9, 1.0)
+	var capacity: int = int(floor(perimeter / spacing))
+	return max(capacity, 1)
+
+func _can_add_second_door(ring: Dictionary, wall: int) -> bool:
+	if wall == 0 or wall == 2:
+		return float(ring.get("usable_width", 0.0)) > 260.0
+	return float(ring.get("usable_height", 0.0)) > 260.0
+
+func _create_door_layout(ring: Dictionary, wall: int, fraction: float, keys_needed: int, color: Color, door_index: int):
+	var inner_margin: float = float(ring.get("inner_margin", SETTINGS.WALL_THICKNESS + SETTINGS.KEY_WALL_OFFSET))
+	var wall_thickness: float = float(ring.get("wall_thickness", SETTINGS.WALL_THICKNESS))
+	var left: float = float(ring.get("left", 0.0))
+	var right: float = float(ring.get("right", 0.0))
+	var top: float = float(ring.get("top", 0.0))
+	var bottom: float = float(ring.get("bottom", 0.0))
+	var usable_width: float = max(float(ring.get("usable_width", 0.0)), 60.0)
+	var usable_height: float = max(float(ring.get("usable_height", 0.0)), 60.0)
+	var door_width: float = wall_thickness
+	var door_height: float = wall_thickness
+	var position := Vector2.ZERO
+	var center := Vector2.ZERO
+	var clamped_fraction = clamp(fraction, 0.18, 0.82)
+	match wall:
+		0:
+			var span_max_x = max(usable_width - 40.0, 48.0)
+			var span_min_x = min(span_max_x, 110.0)
+			door_width = clamp(usable_width * 0.55, span_min_x, span_max_x)
+			var start_x = left + inner_margin
+			var end_x = max(start_x, right - inner_margin - door_width)
+			var door_left = clamp(start_x + usable_width * clamped_fraction - door_width * 0.5, start_x, end_x)
+			position = Vector2(door_left, top - wall_thickness)
+			center = Vector2(door_left + door_width * 0.5, top)
+		1:
+			var span_max_y = max(usable_height - 40.0, 48.0)
+			var span_min_y = min(span_max_y, 110.0)
+			door_height = clamp(usable_height * 0.55, span_min_y, span_max_y)
+			var start_y = top + inner_margin
+			var end_y = max(start_y, bottom - inner_margin - door_height)
+			var door_top = clamp(start_y + usable_height * clamped_fraction - door_height * 0.5, start_y, end_y)
+			position = Vector2(right - wall_thickness, door_top)
+			center = Vector2(right, door_top + door_height * 0.5)
+		2:
+			var span_max_bottom = max(usable_width - 40.0, 48.0)
+			var span_min_bottom = min(span_max_bottom, 110.0)
+			door_width = clamp(usable_width * 0.55, span_min_bottom, span_max_bottom)
+			var start_x_bottom = left + inner_margin
+			var end_x_bottom = max(start_x_bottom, right - inner_margin - door_width)
+			var bottom_left = clamp(start_x_bottom + usable_width * clamped_fraction - door_width * 0.5, start_x_bottom, end_x_bottom)
+			position = Vector2(bottom_left, bottom - wall_thickness)
+			center = Vector2(bottom_left + door_width * 0.5, bottom)
+		3:
+			var span_max_left = max(usable_height - 40.0, 48.0)
+			var span_min_left = min(span_max_left, 110.0)
+			door_height = clamp(usable_height * 0.55, span_min_left, span_max_left)
+			var start_y_left = top + inner_margin
+			var end_y_left = max(start_y_left, bottom - inner_margin - door_height)
+			var left_top = clamp(start_y_left + usable_height * clamped_fraction - door_height * 0.5, start_y_left, end_y_left)
+			position = Vector2(left, left_top)
+			center = Vector2(left, left_top + door_height * 0.5)
+		_:
+			return null
+	return {
+		"index": door_index,
+		"wall": wall,
+		"fraction": clamped_fraction,
+		"position": position,
+		"size": Vector2(door_width, door_height),
+		"center": center,
+		"keys_needed": keys_needed,
+		"initially_open": false,
+		"color": color
+	}

--- a/scripts/level_generators/key/KeyRingSettings.gd
+++ b/scripts/level_generators/key/KeyRingSettings.gd
@@ -1,0 +1,11 @@
+extends RefCounted
+class_name KeyRingSettings
+
+const BARRIER_COLOR := Color(0.18, 0.21, 0.32, 1)
+const RING_OUTER_MARGIN := 120.0
+const MIN_RING_SPACING := 150.0
+const MIN_INNER_HALF := 120.0
+const WALL_THICKNESS := 52.0
+const KEY_SEPARATION := 90.0
+const KEY_WALL_OFFSET := 60.0
+const SECOND_DOOR_PROBABILITY := 0.35

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,3 +24,8 @@ Set `GODOT_BIN` to an existing executable if you prefer to use a previously inst
 If the execution environment does not have internet access, download the official **Godot 4.2 (or newer)** headless build beforehand on a machine with connectivity and place it at `bin/godot` (or expose it via `GODOT_BIN`). Make sure it is executable (`chmod +x bin/godot`).
 
 Once the binary is present, the test runner can be invoked in offline environments without further setup.
+
+## Test coverage highlights
+
+- `tests/unit/test_key_mode_generation.gd` exercises the nested key-ring planner, door spawner, and maze-with-keys pathing to ensure every barrier is blocking until its matching perimeter keys are collected.
+- `tests/unit/test_utils.gd` now includes typed helpers such as `assert_between`, `assert_instanceof`, and `assert_array_size` so suites can express intent clearly while keeping indentation consistent with tabs.

--- a/tests/unit/test_game_state.gd
+++ b/tests/unit/test_game_state.gd
@@ -76,7 +76,7 @@ func test_challenge_sequence_cycles_modes() -> void:
 	state.set_level_type(GameState.LevelType.CHALLENGE)
 	assert_eq(state.selected_level_type, GameState.LevelType.CHALLENGE)
 	assert_eq(state.challenge_sequence.size(), 7)
-	var allowed := [GameState.LevelType.OBSTACLES_COINS, GameState.LevelType.KEYS, GameState.LevelType.MAZE, GameState.LevelType.MAZE_COINS, GameState.LevelType.MAZE_KEYS]
+	var allowed := [GameState.LevelType.OBSTACLES_COINS, GameState.LevelType.KEYS, GameState.LevelType.MAZE, GameState.LevelType.MAZE_COINS, GameState.LevelType.MAZE_KEYS, GameState.LevelType.MAZE_COMPLEX, GameState.LevelType.MAZE_COMPLEX_COINS]
 	for mode in state.challenge_sequence:
 		assert_true(allowed.has(mode))
 	var first_mode := state.get_current_level_type()

--- a/tests/unit/test_key_mode_generation.gd
+++ b/tests/unit/test_key_mode_generation.gd
@@ -1,0 +1,196 @@
+extends "res://tests/unit/test_utils.gd"
+
+const KeyRingLayoutPlanner = preload("res://scripts/level_generators/key/KeyRingLayoutPlanner.gd")
+const KeyRingDoorSpawner = preload("res://scripts/level_generators/key/KeyRingDoorSpawner.gd")
+const MazeGenerator = preload("res://scripts/level_generators/MazeGenerator.gd")
+
+class KeyRingContextStub extends RefCounted:
+	var suite
+	var doors: Array = []
+	var key_items: Array = []
+	var key_barriers: Array = []
+	var obstacles: Array = []
+	var generated_nodes: Array = []
+	var palette := [Color(0.92, 0.45, 0.32), Color(0.32, 0.58, 0.92), Color(0.52, 0.78, 0.36)]
+
+	func _init(test_suite):
+		suite = test_suite
+
+	func get_group_color(index: int) -> Color:
+		return palette[index % palette.size()]
+
+	func add_generated_node(node, _scene) -> void:
+		generated_nodes.append(node)
+		if node is Node:
+			suite.track_node(node)
+
+class ObstacleUtilsStub extends RefCounted:
+	var cleared_positions: Array = []
+
+	func clear_around_position(position: Vector2, radius: float) -> void:
+		cleared_positions.append({"position": position, "radius": radius})
+
+class ExitSpawnerStub extends Node:
+	var suite
+	var exit_node: Area2D = null
+	var positions: Array = []
+
+	func _init(test_suite):
+		suite = test_suite
+
+	func clear_exit() -> void:
+		if exit_node and exit_node.is_inside_tree():
+			exit_node.queue_free()
+		exit_node = null
+
+	func create_exit_at(position: Vector2, _scene) -> void:
+		positions.append(position)
+		exit_node = suite.track_node(Area2D.new())
+		exit_node.position = position
+
+	func get_exit() -> Area2D:
+		return exit_node
+
+class MazeKeyContextStub extends Node:
+	var suite
+	var doors: Array = []
+	var key_items: Array = []
+	var key_barriers: Array = []
+	var maze_walls: Array = []
+	var coins: Array = []
+	var last_maze_path_length: float = 0.0
+	var obstacles: Array = []
+	var exit_pos: Vector2 = Vector2.ZERO
+	var exit_spawner: ExitSpawnerStub
+	var spawn_override: Vector2 = Vector2.ZERO
+	var current_level_size: float = 1.0
+	var palette := [Color(0.86, 0.33, 0.41), Color(0.31, 0.74, 0.62), Color(0.62, 0.48, 0.92)]
+
+	func _init(test_suite):
+		suite = test_suite
+		exit_spawner = suite.track_node(ExitSpawnerStub.new(suite))
+
+	func get_group_color(index: int) -> Color:
+		return palette[index % palette.size()]
+
+	func add_generated_node(node, _scene) -> void:
+		if node is Node:
+			suite.track_node(node)
+		if node is StaticBody2D and node.name.begins_with("Door"):
+			doors.append(node)
+		elif node is StaticBody2D and node.name.begins_with("DoorBarrier"):
+			key_barriers.append(node)
+		elif node is Area2D and node.name.begins_with("Key"):
+			key_items.append(node)
+
+	func set_player_spawn_override(position: Vector2) -> void:
+		spawn_override = position
+
+	func get_maze_cell_size() -> float:
+		return 48.0
+
+	func get_maze_wall_size_ratio() -> float:
+		return 0.12
+
+	func is_maze_full_cover() -> bool:
+		return true
+
+class MazeGeneratorProbe extends MazeGenerator:
+	var layout_override: Dictionary = {}
+
+	func set_layout(layout: Dictionary) -> void:
+		layout_override = layout
+
+	func _build_layout(_main_scene, _player_start_position: Vector2) -> Dictionary:
+		return layout_override
+
+func get_suite_name() -> String:
+	return "KeyModeGeneration"
+
+func test_key_ring_layout_creates_nested_rings_with_doors() -> void:
+	var context := KeyRingContextStub.new(self)
+	var planner := KeyRingLayoutPlanner.new(context)
+	var layout := planner.create_layout(Vector2.ZERO, 800.0, 600.0, 6)
+	var rings: Array = layout.get("rings", [])
+	assert_true(rings.size() >= 2)
+	var outer: Dictionary = rings[0]
+	var inner: Dictionary = rings[rings.size() - 1]
+	var spawn: Vector2 = layout.get("spawn", Vector2.ZERO)
+	assert_true(spawn.x <= float(outer.get("left", spawn.x + 1.0)))
+	assert_between(spawn.y, float(outer.get("top", spawn.y)) + 80.0, float(outer.get("bottom", spawn.y)) - 80.0)
+	var exit_position: Vector2 = layout.get("exit", Vector2.ZERO)
+	assert_vector_near(exit_position, inner.get("center", Vector2.ZERO), 0.01)
+	var total_doors := 0
+	for ring in rings:
+		var doors: Array = ring.get("doors", [])
+		total_doors += doors.size()
+		for door in doors:
+			assert_between(float(door.get("fraction", 0.5)), 0.18, 0.82)
+			assert_true(door.has("position"))
+	assert_true(total_doors >= rings.size())
+
+func test_key_ring_door_spawner_emits_blocking_door_and_perimeter_keys() -> void:
+	var context := KeyRingContextStub.new(self)
+	var planner := KeyRingLayoutPlanner.new(context)
+	var layout := planner.create_layout(Vector2.ZERO, 720.0, 540.0, 5)
+	var rings: Array = layout.get("rings", [])
+	var obstacle_utils := ObstacleUtilsStub.new()
+	var spawner: KeyRingDoorSpawner = KeyRingDoorSpawner.new(context, obstacle_utils)
+	spawner.spawn(rings, null)
+	assert_true(context.doors.size() >= 1)
+	assert_true(context.key_items.size() >= context.doors.size())
+	for door in context.doors:
+		assert_false(door.initially_open)
+		assert_true(door.required_keys > 0)
+	assert_eq(obstacle_utils.cleared_positions.size(), context.key_items.size())
+	for key in context.key_items:
+		assert_instanceof(key, "Area2D")
+		var aligned := false
+		for ring in rings:
+			var margin: float = float(ring.get("inner_margin", 0.0))
+			var top := float(ring.get("top", 0.0)) + margin
+			var bottom := float(ring.get("bottom", 0.0)) - margin
+			var left := float(ring.get("left", 0.0)) + margin
+			var right := float(ring.get("right", 0.0)) - margin
+			if abs(key.position.y - top) <= 1.5 or abs(key.position.y - bottom) <= 1.5 or abs(key.position.x - left) <= 1.5 or abs(key.position.x - right) <= 1.5:
+				aligned = true
+				break
+		assert_true(aligned, "Key should align to ring perimeter")
+
+func test_maze_generator_keys_mode_spawns_blocking_doors_and_keys() -> void:
+	var context := track_node(MazeKeyContextStub.new(self))
+	var generator := MazeGeneratorProbe.new(context, null)
+	var cell_size := 48.0
+	var grid: Array = []
+	for y in range(5):
+		var row: Array = []
+		for x in range(5):
+			row.append(true)
+		grid.append(row)
+	var open_cells := [Vector2i(1, 1), Vector2i(2, 1), Vector2i(3, 1), Vector2i(3, 2), Vector2i(3, 3), Vector2i(2, 3)]
+	for cell in open_cells:
+		grid[cell.y][cell.x] = false
+	var start_cell := Vector2i(1, 1)
+	var layout := {
+		"grid": grid,
+		"cols": 5,
+		"rows": 5,
+		"cell_size": cell_size,
+		"maze_offset": Vector2.ZERO,
+		"start_cell": start_cell,
+		"start_world": Vector2(cell_size * (start_cell.x + 0.5), cell_size * (start_cell.y + 0.5))
+	}
+	generator.set_layout(layout)
+	generator.generate_maze_keys_level(null, 4, Vector2.ZERO)
+	assert_true(context.doors.size() >= 1)
+	assert_true(context.key_items.size() >= context.doors.size())
+	for door in context.doors:
+		assert_false(door.initially_open)
+		assert_true(door.required_keys > 0)
+	for key in context.key_items:
+		assert_true(key.door_reference != null)
+		assert_true(key.required_key_count >= key.door_reference.required_keys)
+	assert_true(context.exit_spawner.get_exit() != null)
+	assert_vector_near(context.exit_pos, context.exit_spawner.get_exit().position, 0.001)
+	var expected_spawn := Vector2(cell_size * (start_cell.x + 0.5), cell_size * (start_cell.y + 0.5))
+	assert_vector_near(context.spawn_override, expected_spawn, 0.001)

--- a/tests/unit/test_level_generation_scripts.gd
+++ b/tests/unit/test_level_generation_scripts.gd
@@ -83,16 +83,16 @@ func test_obstacle_utilities_clears_near_points() -> void:
 	assert_false(context.obstacles.has(close_obstacle))
 	assert_true(context.obstacles.has(far_obstacle))
 
-func test_key_level_generator_sample_far_points_within_bounds() -> void:
-	var generator := KeyLevelGenerator.new({}, null)
+func test_key_placement_utils_sample_far_points_within_bounds() -> void:
 	seed(1)
-	var points := generator._sample_far_points(3, Vector2(10, 20), 200.0, 150.0, 40.0)
-	assert_eq(points.size(), 3)
+	var offset := Vector2(10, 20)
+	var width := 200.0
+	var height := 150.0
+	var points := KeyPlacementUtils.sample_far_points(4, offset, width, height, 60.0)
+	assert_eq(points.size(), 4)
 	for point in points:
-		assert_true(point.x >= 10.0)
-		assert_true(point.x <= 210.0)
-		assert_true(point.y >= 20.0)
-		assert_true(point.y <= 170.0)
+		assert_between(point.x, offset.x, offset.x + width)
+		assert_between(point.y, offset.y, offset.y + height)
 
 func test_key_door_planner_respects_bounds_and_obstacles() -> void:
 	var context := KeyPlannerContextStub.new()

--- a/tests/unit/test_utils.gd
+++ b/tests/unit/test_utils.gd
@@ -84,6 +84,31 @@ func assert_array_contains(collection: Array, value, message := "") -> void:
 		var detail := "Expected collection to contain %s" % str(value)
 		_register_failure(_compose_message(message, detail))
 
+func assert_between(value, min_value, max_value, message := "") -> void:
+	_assertions += 1
+	var lower: float = float(min(min_value, max_value))
+	var upper: float = float(max(min_value, max_value))
+	var numeric: float = float(value)
+	if numeric < lower or numeric > upper:
+		var detail := "Expected %.3f within [%.3f, %.3f]" % [numeric, lower, upper]
+		_register_failure(_compose_message(message, detail))
+
+func assert_instanceof(subject, expected_class, message := "") -> void:
+	_assertions += 1
+	var is_match := false
+	if subject is Object:
+		var target_name := str(expected_class)
+		is_match = subject.is_class(target_name)
+	if not is_match:
+		var detail := "Expected instance of %s" % str(expected_class)
+		_register_failure(_compose_message(message, detail))
+
+func assert_array_size(collection: Array, expected_size: int, message := "") -> void:
+	_assertions += 1
+	if collection.size() != expected_size:
+		var detail := "Expected array size %d but got %d" % [expected_size, collection.size()]
+		_register_failure(_compose_message(message, detail))
+
 func track_node(node: Node) -> Node:
 	_nodes_to_free.append(node)
 	return node


### PR DESCRIPTION
## Summary
- refine the key ring layout to cap keys per ring, maintain usable spacing, and document the nested arena flow in the README
- harden the key door spawner with perimeter fallbacks and slimmer door spans while making the maze key generator always place blocking keys and set the spawn override
- add dedicated key mode unit tests, extend the test utilities, and document the new coverage in the test guide

## Testing
- tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2aacb0dc88323903671a0097b7b36