### PR TITLE
Rewrite key level generator to produce deterministic grid maps

### DIFF
--- a/scripts/LevelGenerator.gd
+++ b/scripts/LevelGenerator.gd
@@ -247,16 +247,23 @@ func _clear_non_maze_obstacles(main_scene) -> void:
 	if not obstacles.is_empty():
 		_queue_free_nodes(obstacles)
 	obstacles.clear()
-	_clear_named_children(self, ["Obstacle"])
+	var prefixes: Array[String] = ["Obstacle", "ObstacleShadow", "Border"]
+	_clear_named_children(self, prefixes, [obstacle_spawner, coin_spawner, exit_spawner])
 	if main_scene and main_scene is Node:
-		_clear_named_children(main_scene, ["Obstacle"])
+		_clear_named_children(main_scene, prefixes)
 
-func _clear_named_children(root: Node, prefixes: Array[String]) -> void:
+func _clear_named_children(root: Node, prefixes: Array[String], skip_nodes: Array = []) -> void:
 	if root == null:
 		return
+	var skip_lookup: Dictionary = {}
+	for node in skip_nodes:
+		if node and is_instance_valid(node):
+			skip_lookup[node] = true
 	var pending: Array = []
 	for child in root.get_children():
 		var node_child: Node = child
+		if skip_lookup.has(node_child):
+			continue
 		var name: String = node_child.name
 		for prefix in prefixes:
 			if name.begins_with(prefix):
@@ -266,7 +273,7 @@ func _clear_named_children(root: Node, prefixes: Array[String]) -> void:
 		if is_instance_valid(node):
 			node.queue_free()
 
-func _clear_spawner(spawner: Node, method_name: String) -> void:
+func _clear_spawner(spawner, method_name: String) -> void:
 	if spawner and is_instance_valid(spawner) and spawner.has_method(method_name):
 		spawner.call(method_name)
 

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -315,14 +315,15 @@ func _validate_map(grid: Array, start: Vector2i, exit_cell: Vector2i, door_infos
 	var final_reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
 	return final_reachable.has(exit_cell)
 
+
 func _spawn_from_grid(layout: Dictionary, dims: Dictionary, main_scene) -> void:
 	if context == null:
 		return
 	context.obstacles = []
 	context.doors = []
-	context.key_items = []
+	context.key_items.clear()
 	context.key_barriers = []
-	context.coins = []
+	context.coins.clear()
 	var grid: Array = layout.get("grid", [])
 	if grid.is_empty():
 		return

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -1,416 +1,511 @@
-extends RefCounted
+extends Node
 
-class_name KeyLevelGenerator
+class_name KeysGenerator
 
-const LOGGER := preload("res://scripts/Logger.gd")
-const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
-const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
+const EDGE_TYPE_OPEN := StringName("open")
+const EDGE_TYPE_WALL := StringName("wall")
+const EDGE_TYPE_DOOR := StringName("door")
 
-const MIN_GRID_SIZE := 12
-const MAX_GRID_SIZE := 20
-const MIN_CELL_SIZE := 32.0
-const MAX_GENERATION_ATTEMPTS := 32
-const OBSTACLE_RATIO := 0.12
-const COLORS := ["R", "Y", "B", "P"]
-const OUTER_OBSTACLE_COLOR := Color(0.36, 0.17, 0.08, 1.0)
-const INNER_OBSTACLE_COLOR := Color(0.55, 0.55, 0.55, 1.0)
+const MIN_DIMENSION := 14
+const MAX_DIMENSION := 22
+const MIN_DOOR_PAIRS := 2
+const MAX_DOOR_PAIRS := 4
+const MAX_ATTEMPTS := 64
+const EXTRA_EDGE_CHANCE := 0.32
+const THIN_WALL_TRIES := 12
+const MAX_THIN_WALLS := 3
 
-var context
-var obstacle_utils
-var last_generated_grid: Array = []
+const COLOR_SEQUENCE := [StringName("Y"), StringName("R"), StringName("B"), StringName("P")]
+const COLOR_MAP := {
+	StringName("Y"): Color(1.0, 0.756863, 0.027451, 1.0),
+	StringName("R"): Color(0.956863, 0.262745, 0.211765, 1.0),
+	StringName("B"): Color(0.129412, 0.588235, 0.952941, 1.0),
+	StringName("P"): Color(0.611765, 0.152941, 0.690196, 1.0)
+}
 
-var _rng := RandomNumberGenerator.new()
-var _use_custom_seed := false
-var _seed_value := 0
+@export var cell_size: int = 32
+@export var line_thickness: float = 0.12
 
-func _init(level_context, obstacle_helper):
-	context = level_context
-	obstacle_utils = obstacle_helper
-	_rng.randomize()
+var origin_offset: Vector2 = Vector2.ZERO
+var last_render_data: Dictionary = {}
+class EdgeSpec:
+	var type: StringName
+	var color: StringName
 
-func set_seed(value: int) -> void:
-	_use_custom_seed = true
-	_seed_value = value
+	func _init(t: StringName = EDGE_TYPE_OPEN, c: StringName = StringName()):
+		type = t
+		color = c
 
-func get_last_generated_grid() -> Array:
-	return last_generated_grid
+class KeySpec:
+	var cell: Vector2i
+	var color: StringName
 
-func generate(main_scene, level: int, player_start_position: Vector2) -> void:
-	var dims: Dictionary = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
-	_reset_rng(level)
-	var layout: Dictionary = _build_level_layout(level, dims)
-	if layout.is_empty():
-		LOGGER.log_error("KeyLevelGenerator failed to build solvable layout")
-		return
-	last_generated_grid = layout.get("grid", [])
-	_spawn_from_grid(layout, dims, main_scene)
+	func _init(p_cell: Vector2i, p_color: StringName):
+		cell = p_cell
+		color = p_color
 
-func _reset_rng(level: int) -> void:
-	if _use_custom_seed:
-		_rng.seed = _seed_value
+class DoorSpec:
+	var a: Vector2i
+	var b: Vector2i
+	var color: StringName
+
+	func _init(p_a: Vector2i, p_b: Vector2i, p_color: StringName):
+		a = p_a
+		b = p_b
+		color = p_color
+
+class WallSpec:
+	var a: Vector2i
+	var b: Vector2i
+
+	func _init(p_a: Vector2i, p_b: Vector2i):
+		a = p_a
+		b = p_b
+
+class KeysLevel:
+	var width: int
+	var height: int
+	var start: Vector2i
+	var exit: Vector2i
+	var keys: Array[KeySpec] = []
+	var doors: Array[DoorSpec] = []
+	var thin_walls: Array[WallSpec] = []
+	var adjacency: Dictionary = {}
+
+	func _init(p_width: int, p_height: int, p_start: Vector2i, p_exit: Vector2i, p_adjacency: Dictionary):
+		width = p_width
+		height = p_height
+		start = p_start
+		exit = p_exit
+		adjacency = p_adjacency
+
+	func get_edge(a: Vector2i, b: Vector2i) -> EdgeSpec:
+		if adjacency.has(a) and adjacency[a].has(b):
+			return adjacency[a][b]
+		return null
+
+func generate(seed: int = 0, door_pairs: int = -1) -> KeysLevel:
+	var rng := RandomNumberGenerator.new()
+	if seed == 0:
+		rng.randomize()
 	else:
-		_rng.seed = hash([Time.get_ticks_usec(), level, randi()])
-
-func _build_level_layout(level: int, dims: Dictionary) -> Dictionary:
-	var max_cols: int = int(floor(dims.width / MIN_CELL_SIZE))
-	var max_rows: int = int(floor(dims.height / MIN_CELL_SIZE))
-	max_cols = max(MIN_GRID_SIZE, min(MAX_GRID_SIZE, max_cols))
-	max_rows = max(MIN_GRID_SIZE, min(MAX_GRID_SIZE, max_rows))
-	for attempt in range(MAX_GENERATION_ATTEMPTS):
-		var width: int = _rng.randi_range(MIN_GRID_SIZE, max_cols)
-		var height: int = _rng.randi_range(MIN_GRID_SIZE, max_rows)
-		var grid: Array = _create_empty_grid(width, height)
-		var start: Vector2i = Vector2i(width / 2, height / 2)
-		var exit_cell: Variant = _choose_exit_cell(width, height, start)
-		if exit_cell == null:
+		rng.seed = seed
+	for _attempt in range(MAX_ATTEMPTS):
+		var width := rng.randi_range(MIN_DIMENSION, MAX_DIMENSION)
+		var height := rng.randi_range(MIN_DIMENSION, MAX_DIMENSION)
+		var start := Vector2i(width / 2, height / 2)
+		var build: Dictionary = _build_base_graph(width, height, start, rng)
+		if build.is_empty():
 			continue
-		_place_outer_walls(grid)
-		if not _place_internal_obstacles(grid, start, exit_cell):
+		var adjacency: Dictionary = build["adjacency"]
+		var exit_cell: Vector2i = _select_exit(start, adjacency)
+		var path: Array[Vector2i] = _bfs_path(start, exit_cell, adjacency)
+		if path.size() < 6:
 			continue
-		var path: Array = _find_path(grid, start, exit_cell)
-		if path.is_empty():
+		var max_pairs: int = min(MAX_DOOR_PAIRS, int((path.size() - 2) / 2))
+		if max_pairs < MIN_DOOR_PAIRS:
 			continue
-		var door_count: int = _select_door_count(path.size())
-		if door_count < 2:
+		var target_pairs := door_pairs
+		if target_pairs < MIN_DOOR_PAIRS:
+			target_pairs = rng.randi_range(MIN_DOOR_PAIRS, max_pairs)
+		target_pairs = clamp(target_pairs, MIN_DOOR_PAIRS, max_pairs)
+		var colors: Array[StringName] = []
+		for color_index in range(target_pairs):
+			colors.append(COLOR_SEQUENCE[color_index])
+		_shuffle_with_rng(colors, rng)
+		var placement: Dictionary = _place_keys_and_doors(path, colors, adjacency, rng)
+		if placement.is_empty():
 			continue
-		var door_infos: Array = _place_doors_on_path(grid, path, door_count)
-		if door_infos.is_empty():
+		var level := KeysLevel.new(width, height, start, exit_cell, adjacency)
+		level.keys = placement["keys"]
+		level.doors = placement["doors"]
+		_add_thin_walls(level, path, rng)
+		if not _validate_level(level):
 			continue
-		var key_infos: Array = _place_keys(grid, start, door_infos, path, exit_cell)
-		if key_infos.is_empty() or key_infos.size() != door_infos.size():
-			continue
-		grid[start.y][start.x] = "S"
-		grid[exit_cell.y][exit_cell.x] = "E"
-		if not _validate_map(grid, start, exit_cell, door_infos, key_infos):
-			continue
-		return {
-			"grid": grid,
-			"start": start,
-			"exit": exit_cell,
-			"doors": door_infos,
-			"keys": key_infos
-		}
-	return {}
-
-func _select_door_count(path_length: int) -> int:
-	var max_pairs: int = min(COLORS.size(), 4)
-	var min_pairs: int = 2
-	var span: int = max(path_length - 6, 1)
-	var target: int = clamp(int(floor(span / 6)), min_pairs, max_pairs)
-	return clamp(_rng.randi_range(min_pairs, max_pairs), min_pairs, target)
-
-func _create_empty_grid(width: int, height: int) -> Array:
-	var result: Array = []
-	for _y in range(height):
-		var row: Array = []
-		for _x in range(width):
-			row.append(".")
-		result.append(row)
-	return result
-
-func _place_outer_walls(grid: Array) -> void:
-	var height: int = grid.size()
-	var width: int = grid[0].size()
-	for x in range(width):
-		grid[0][x] = "#"
-		grid[height - 1][x] = "#"
-	for y in range(height):
-		grid[y][0] = "#"
-		grid[y][width - 1] = "#"
-
-func _choose_exit_cell(width: int, height: int, start: Vector2i) -> Variant:
-	var candidates: Array = []
-	for x in range(2, width - 2):
-		candidates.append(Vector2i(x, 1))
-		candidates.append(Vector2i(x, height - 2))
-	for y in range(2, height - 2):
-		candidates.append(Vector2i(1, y))
-		candidates.append(Vector2i(width - 2, y))
-	while not candidates.is_empty():
-		var index: int = _rng.randi_range(0, candidates.size() - 1)
-		var cell: Vector2i = candidates[index]
-		candidates.remove_at(index)
-		if cell == start:
-			continue
-		return cell
+		return level
 	return null
 
-func _place_internal_obstacles(grid: Array, start: Vector2i, exit_cell: Vector2i) -> bool:
-	var height: int = grid.size()
-	var width: int = grid[0].size()
-	var interior: Array = []
-	for y in range(1, height - 1):
-		for x in range(1, width - 1):
-			var cell: Vector2i = Vector2i(x, y)
-			if cell == start or cell == exit_cell:
-				continue
-			interior.append(cell)
-	var desired: int = int(ceil(interior.size() * OBSTACLE_RATIO))
-	var attempts: int = 0
-	while attempts < interior.size() and desired > 0:
-		var index: int = _rng.randi_range(0, interior.size() - 1)
-		var cell: Vector2i = interior[index]
-		interior.remove_at(index)
-		var prev: String = String(grid[cell.y][cell.x])
-		grid[cell.y][cell.x] = "#"
-		if _has_path(grid, start, exit_cell):
-			desired -= 1
-		else:
-			grid[cell.y][cell.x] = prev
-		attempts += 1
-	return _has_path(grid, start, exit_cell)
+func render(level: KeysLevel, parent: Node) -> void:
+	if level == null or parent == null:
+		return
+	last_render_data = {
+		"container": null,
+		"door_lines": [] as Array[Line2D],
+		"door_bodies": [] as Array[StaticBody2D],
+		"wall_lines": [] as Array[Line2D],
+		"wall_bodies": [] as Array[StaticBody2D],
+		"keys": [] as Array[Area2D],
+		"exit": null
+	}
+	var container: Node2D = Node2D.new()
+	container.name = "KeysLevel"
+	container.position = origin_offset
+	parent.add_child(container)
+	last_render_data["container"] = container
+	var thickness_px: float = clamp(cell_size * line_thickness, 2.0, 8.0)
+	for wall in level.thin_walls:
+		var wall_line: Line2D = _draw_edge(container, wall.a, wall.b, thickness_px, Color.WHITE, true)
+		(last_render_data["wall_lines"] as Array[Line2D]).append(wall_line)
+	for door in level.doors:
+		var color: Color = COLOR_MAP.get(door.color, Color.WHITE)
+		var door_line: Line2D = _draw_edge(container, door.a, door.b, thickness_px, color, false)
+		var door_body: StaticBody2D = _draw_collision(container, door.a, door.b, thickness_px)
+		(last_render_data["door_lines"] as Array[Line2D]).append(door_line)
+		(last_render_data["door_bodies"] as Array[StaticBody2D]).append(door_body)
+	for wall in level.thin_walls:
+		var wall_body: StaticBody2D = _draw_collision(container, wall.a, wall.b, thickness_px)
+		(last_render_data["wall_bodies"] as Array[StaticBody2D]).append(wall_body)
+	var key_size: float = min(cell_size * 0.35, cell_size * 0.4)
+	for key_spec in level.keys:
+		var key_node: Area2D = _draw_key(container, key_spec, key_size)
+		(last_render_data["keys"] as Array[Area2D]).append(key_node)
+	var exit_rect: ColorRect = _draw_exit(container, level.exit)
+	last_render_data["exit"] = exit_rect
 
-func _has_path(grid: Array, start: Vector2i, goal: Vector2i) -> bool:
-	return not _find_path(grid, start, goal).is_empty()
+func get_render_data() -> Dictionary:
+	return last_render_data.duplicate(true)
 
-func _find_path(grid: Array, start: Vector2i, goal: Vector2i) -> Array:
-	var width: int = grid[0].size()
-	var height: int = grid.size()
-	var queue: Array = [start]
-	var came_from: Dictionary = {}
-	came_from[start] = start
+func cell_to_world(cell: Vector2i) -> Vector2:
+	return Vector2((cell.x + 0.5) * float(cell_size), (cell.y + 0.5) * float(cell_size)) + origin_offset
+
+func find_path_with_keys(level: KeysLevel) -> Array[Vector2i]:
+	if level == null:
+		return []
+	var color_to_bit: Dictionary = {}
+	for i in range(level.keys.size()):
+		color_to_bit[level.keys[i].color] = i
+	var key_lookup: Dictionary = {}
+	for key_spec in level.keys:
+		key_lookup[key_spec.cell] = key_spec.color
+	var start_state := Vector3i(level.start.x, level.start.y, 0)
+	var queue: Array[Vector3i] = [start_state]
+	var visited: Dictionary = {}
+	visited[start_state] = null
 	while not queue.is_empty():
-		var cell: Vector2i = queue.pop_front()
-		if cell == goal:
-			return _reconstruct_path(came_from, start, goal)
-		for neighbor in _neighbors(cell, width, height):
-			if came_from.has(neighbor):
+		var state: Vector3i = queue.pop_front()
+		var cell := Vector2i(state.x, state.y)
+		var mask := state.z
+		if cell == level.exit:
+			return _reconstruct_path(visited, state)
+		for neighbor in level.adjacency.get(cell, {}):
+			var edge: EdgeSpec = level.adjacency[cell][neighbor]
+			if edge == null or edge.type == EDGE_TYPE_WALL:
 				continue
-			var tile: String = grid[neighbor.y][neighbor.x]
-			if tile == "#":
-				continue
-			came_from[neighbor] = cell
-			queue.append(neighbor)
+			if edge.type == EDGE_TYPE_DOOR:
+				var bit: int = color_to_bit.get(edge.color, -1)
+				if bit == -1 or (mask & (1 << bit)) == 0:
+					continue
+			var next_mask: int = mask
+			if key_lookup.has(neighbor):
+				var bit_index: int = color_to_bit.get(key_lookup[neighbor], -1)
+				if bit_index >= 0:
+					next_mask = next_mask | (1 << bit_index)
+			var next_state: Vector3i = Vector3i(neighbor.x, neighbor.y, next_mask)
+			if not visited.has(next_state):
+				visited[next_state] = state
+				queue.append(next_state)
 	return []
 
-func _reconstruct_path(came_from: Dictionary, start: Vector2i, goal: Vector2i) -> Array:
-	var path: Array = []
-	var current: Vector2i = goal
-	while current != start:
-		path.push_front(current)
-		current = came_from.get(current, start)
-	path.push_front(start)
-	return path
-
-func _neighbors(cell: Vector2i, width: int, height: int) -> Array:
-	var result: Array = []
-	var deltas: Array = [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]
-	for delta in deltas:
-		var next: Vector2i = cell + delta
-		if next.x < 0 or next.x >= width or next.y < 0 or next.y >= height:
+func _build_base_graph(width: int, height: int, start: Vector2i, rng: RandomNumberGenerator) -> Dictionary:
+	var adjacency: Dictionary = {}
+	for y in range(height):
+		for x in range(width):
+			adjacency[Vector2i(x, y)] = {}
+	var stack: Array[Vector2i] = [start]
+	var visited: Dictionary = {start: true}
+	while not stack.is_empty():
+		var current: Vector2i = stack.back()
+		var options: Array[Vector2i] = []
+		for dir in [[1, 0], [-1, 0], [0, 1], [0, -1]]:
+			var next := Vector2i(current.x + dir[0], current.y + dir[1])
+			if next.x < 0 or next.y < 0 or next.x >= width or next.y >= height:
+				continue
+			if visited.has(next):
+				continue
+			options.append(next)
+		if options.is_empty():
+			stack.pop_back()
 			continue
-		result.append(next)
-	return result
+		_shuffle_with_rng(options, rng)
+		var chosen: Vector2i = options.front()
+		visited[chosen] = true
+		stack.append(chosen)
+		_link_cells(adjacency, current, chosen, EDGE_TYPE_OPEN, StringName())
+	for y in range(height):
+		for x in range(width):
+			var cell := Vector2i(x, y)
+			for offset in [[1, 0], [0, 1]]:
+				var neighbor := Vector2i(x + offset[0], y + offset[1])
+				if neighbor.x >= width or neighbor.y >= height:
+					continue
+				if adjacency[cell].has(neighbor):
+					continue
+				if rng.randf() < EXTRA_EDGE_CHANCE:
+					_link_cells(adjacency, cell, neighbor, EDGE_TYPE_OPEN, StringName())
+	return {"adjacency": adjacency}
 
-func _place_doors_on_path(grid: Array, path: Array, door_count: int) -> Array:
-	var door_infos: Array = []
-	var step: int = max(2, int(floor(path.size() / float(door_count + 1))))
-	var last_index: int = 1
-	for i in range(door_count):
-		var min_index: int = last_index + 1
-		var max_index: int = path.size() - (door_count - i) * 2
-		if min_index >= max_index:
-			return []
-		var index: int = clamp(int(round(float(i + 1) * float(step))), min_index, max_index)
-		var cell: Vector2i = path[index]
-		var after_cell: Vector2i = path[index + 1]
-		var color_code: String = COLORS[i % COLORS.size()]
-		grid[cell.y][cell.x] = "D_%s" % color_code
-		door_infos.append({
-			"cell": cell,
-			"after": after_cell,
-			"color": color_code,
-			"tile": "D_%s" % color_code
-		})
-		last_index = index
-	return door_infos
-
-func _place_keys(grid: Array, start: Vector2i, door_infos: Array, path: Array, exit_cell: Vector2i) -> Array:
-	var key_infos: Array = []
-	var collected: Dictionary = {}
-	var path_lookup: Dictionary = {}
-	for cell in path:
-		path_lookup[cell] = true
-	var current_start: Vector2i = start
-	for door_info in door_infos:
-		var reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
-		var candidates: Array = []
-		for cell in reachable.keys():
-			if cell == start or cell == exit_cell:
-				continue
-			if path_lookup.has(cell) and _rng.randf() < 0.6:
-				continue
-			var blocked: bool = false
-			for existing in key_infos:
-				if existing.get("cell", Vector2i(-1, -1)) == cell:
-					blocked = true
-					break
-			if blocked:
-				continue
-			if grid[cell.y][cell.x] == "#":
-				continue
-			candidates.append(cell)
-		if candidates.is_empty():
-			candidates = reachable.keys()
-		if candidates.is_empty():
-			return []
-		var chosen: Vector2i = candidates[_rng.randi_range(0, candidates.size() - 1)]
-		var color_code: String = door_info.get("color", "R")
-		collected[color_code] = true
-		key_infos.append({
-			"cell": chosen,
-			"color": color_code,
-			"tile": "K_%s" % color_code
-		})
-		grid[chosen.y][chosen.x] = "K_%s" % color_code
-		var reachable_after: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
-		var after_cell: Vector2i = door_info.get("after", current_start)
-		if not reachable_after.has(after_cell):
-			return []
-		current_start = after_cell
-	return key_infos
-
-func _flood_fill_with_keys(grid: Array, start: Vector2i, collected: Dictionary) -> Dictionary:
-	var width: int = grid[0].size()
-	var height: int = grid.size()
-	var visited: Dictionary = {}
-	var queue: Array = []
-	if not _is_walkable(grid, start, collected):
-		return visited
-	visited[start] = true
-	queue.append(start)
+func _select_exit(start: Vector2i, adjacency: Dictionary) -> Vector2i:
+	var queue: Array[Vector2i] = [start]
+	var visited: Dictionary = {start: true}
+	var last := start
 	while not queue.is_empty():
 		var cell: Vector2i = queue.pop_front()
-		for neighbor in _neighbors(cell, width, height):
+		last = cell
+		for neighbor in adjacency.get(cell, {}):
 			if visited.has(neighbor):
-				continue
-			if not _is_walkable(grid, neighbor, collected):
 				continue
 			visited[neighbor] = true
 			queue.append(neighbor)
-	return visited
+	return last
 
-func _is_walkable(grid: Array, cell: Vector2i, collected: Dictionary) -> bool:
-	var tile: String = grid[cell.y][cell.x]
-	if tile == "#":
+func _bfs_path(start: Vector2i, goal: Vector2i, adjacency: Dictionary) -> Array[Vector2i]:
+	var queue: Array[Vector2i] = [start]
+	var parent: Dictionary = {start: Vector2i(-1, -1)}
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		if cell == goal:
+			break
+		for neighbor in adjacency.get(cell, {}):
+			if parent.has(neighbor):
+				continue
+			var edge: EdgeSpec = adjacency[cell][neighbor]
+			if edge == null or edge.type == EDGE_TYPE_WALL:
+				continue
+			parent[neighbor] = cell
+			queue.append(neighbor)
+	if not parent.has(goal):
+		return []
+	var path: Array[Vector2i] = []
+	var current := goal
+	while current != Vector2i(-1, -1):
+		path.push_front(current)
+		current = parent.get(current, Vector2i(-1, -1))
+	return path
+
+func _place_keys_and_doors(path: Array[Vector2i], colors: Array, adjacency: Dictionary, rng: RandomNumberGenerator) -> Dictionary:
+	var door_specs: Array[DoorSpec] = []
+	var key_specs: Array[KeySpec] = []
+	var prev_bound := 1
+	for i in range(colors.size()):
+		var remaining := colors.size() - i - 1
+		var max_key_index := path.size() - 2 - (remaining * 2)
+		if max_key_index < prev_bound:
+			return {}
+		var key_index := rng.randi_range(prev_bound, max_key_index)
+		var min_door_index := key_index + 1
+		var max_door_index := path.size() - 1 - (remaining * 2 + 1)
+		if max_door_index < min_door_index:
+			return {}
+		var door_index := rng.randi_range(min_door_index, max_door_index)
+		var key_cell: Vector2i = path[key_index]
+		var door_a: Vector2i = path[door_index - 1]
+		var door_b: Vector2i = path[door_index]
+		var color: StringName = colors[i]
+		key_specs.append(KeySpec.new(key_cell, color))
+		_set_edge_type(adjacency, door_a, door_b, EDGE_TYPE_DOOR, color)
+		door_specs.append(DoorSpec.new(door_a, door_b, color))
+		prev_bound = door_index + 1
+	return {"doors": door_specs, "keys": key_specs}
+
+func _add_thin_walls(level: KeysLevel, path: Array[Vector2i], rng: RandomNumberGenerator) -> void:
+	var path_edges: Dictionary = {}
+	for i in range(1, path.size()):
+		var a := path[i - 1]
+		var b := path[i]
+		path_edges[_edge_key(a, b)] = true
+	var candidates: Array = []
+	var seen: Dictionary = {}
+	for cell in level.adjacency.keys():
+		for neighbor in level.adjacency[cell].keys():
+			var edge_key: String = _edge_key(cell, neighbor)
+			if seen.has(edge_key):
+				continue
+			seen[edge_key] = true
+			var edge: EdgeSpec = level.adjacency[cell][neighbor]
+			if edge == null or edge.type != EDGE_TYPE_OPEN:
+				continue
+			if path_edges.has(edge_key):
+				continue
+			candidates.append([cell, neighbor])
+	_shuffle_with_rng(candidates, rng)
+	var added: int = 0
+	for attempt in range(min(THIN_WALL_TRIES, candidates.size())):
+		if added >= MAX_THIN_WALLS:
+			break
+		var pair: Array = candidates[attempt]
+		var a: Vector2i = pair[0]
+		var b: Vector2i = pair[1]
+		_set_edge_type(level.adjacency, a, b, EDGE_TYPE_WALL, StringName())
+		if _has_basic_path(level, true):
+			level.thin_walls.append(WallSpec.new(a, b))
+			added += 1
+		else:
+			_set_edge_type(level.adjacency, a, b, EDGE_TYPE_OPEN, StringName())
+
+func _validate_level(level: KeysLevel) -> bool:
+	var path: Array[Vector2i] = find_path_with_keys(level)
+	if path.is_empty():
 		return false
-	if tile.begins_with("D_"):
-		var color_code: String = tile.substr(2, tile.length() - 2)
-		return collected.has(color_code)
+	if not _doors_preserve_connectivity(level):
+		return false
+	if not _doors_gate_progress(level):
+		return false
 	return true
 
-func _validate_map(grid: Array, start: Vector2i, exit_cell: Vector2i, door_infos: Array, key_infos: Array) -> bool:
-	var collected: Dictionary = {}
-	var key_lookup: Dictionary = {}
-	for key_info in key_infos:
-		key_lookup[key_info.get("color", "R")] = key_info.get("cell", Vector2i(-1, -1))
-	var current_start: Vector2i = start
-	for door_info in door_infos:
-		var reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
-		var key_cell: Vector2i = key_lookup.get(door_info.get("color", "R"), Vector2i(-1, -1))
-		if not reachable.has(key_cell):
+func _doors_preserve_connectivity(level: KeysLevel) -> bool:
+	var backups: Array = []
+	for door in level.doors:
+		var edge: EdgeSpec = level.get_edge(door.a, door.b)
+		if edge == null:
 			return false
-		var color_code: String = door_info.get("color", "R")
-		collected[color_code] = true
-		var reachable_after: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
-		var after_cell: Vector2i = door_info.get("after", current_start)
-		if not reachable_after.has(after_cell):
+		backups.append([edge, edge.type, edge.color])
+		edge.type = EDGE_TYPE_OPEN
+		edge.color = StringName()
+	var connected: bool = _has_basic_path(level, true)
+	for data in backups:
+		var edge: EdgeSpec = data[0]
+		edge.type = data[1]
+		edge.color = data[2]
+	return connected
+
+func _doors_gate_progress(level: KeysLevel) -> bool:
+	for door in level.doors:
+		var edge: EdgeSpec = level.get_edge(door.a, door.b)
+		if edge == null:
 			return false
-		current_start = after_cell
-	var final_reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
-	return final_reachable.has(exit_cell)
+		var old_type := edge.type
+		var old_color := edge.color
+		edge.type = EDGE_TYPE_WALL
+		var connected: bool = _has_basic_path(level, true)
+		edge.type = old_type
+		edge.color = old_color
+		if connected:
+			return false
+	return true
 
+func _has_basic_path(level: KeysLevel, allow_doors: bool) -> bool:
+	var queue: Array[Vector2i] = [level.start]
+	var visited: Dictionary = {level.start: true}
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		if cell == level.exit:
+			return true
+		for neighbor in level.adjacency.get(cell, {}):
+			if visited.has(neighbor):
+				continue
+			var edge: EdgeSpec = level.adjacency[cell][neighbor]
+			if edge == null:
+				continue
+			if edge.type == EDGE_TYPE_WALL:
+				continue
+			if edge.type == EDGE_TYPE_DOOR and not allow_doors:
+				continue
+			visited[neighbor] = true
+			queue.append(neighbor)
+	return false
 
-func _spawn_from_grid(layout: Dictionary, dims: Dictionary, main_scene) -> void:
-	if context == null:
+func _link_cells(adjacency: Dictionary, a: Vector2i, b: Vector2i, type: StringName, color: StringName) -> void:
+	var edge := EdgeSpec.new(type, color)
+	adjacency[a][b] = edge
+	adjacency[b][a] = edge
+
+func _set_edge_type(adjacency: Dictionary, a: Vector2i, b: Vector2i, type: StringName, color: StringName) -> void:
+	if not adjacency.has(a) or not adjacency[a].has(b):
+		if type == EDGE_TYPE_OPEN:
+			_link_cells(adjacency, a, b, type, color)
 		return
-	context.obstacles = []
-	context.doors = []
-	context.key_items.clear()
-	context.key_barriers = []
-	context.coins.clear()
-	var grid: Array = layout.get("grid", [])
-	if grid.is_empty():
+	var edge: EdgeSpec = adjacency[a][b]
+	if edge == null:
+		edge = EdgeSpec.new(type, color)
+		adjacency[a][b] = edge
+		adjacency[b][a] = edge
 		return
-	var rows: int = grid.size()
-	var cols: int = grid[0].size()
-	var cell_size: float = min(dims.width / float(cols), dims.height / float(rows))
-	var offset_x: float = dims.offset_x + (dims.width - cell_size * cols) * 0.5
-	var offset_y: float = dims.offset_y + (dims.height - cell_size * rows) * 0.5
-	var door_nodes: Dictionary = {}
-	var door_index: int = 0
-	var pending_keys: Array = []
-	if context.exit_spawner and is_instance_valid(context.exit_spawner):
-		context.exit_spawner.clear_exit()
-	for y in range(rows):
-		for x in range(cols):
-			var tile: String = grid[y][x]
-			var cell: Vector2i = Vector2i(x, y)
-			var world_center: Vector2 = _cell_to_world(cell, cell_size, offset_x, offset_y)
-			if tile == "#":
-				var color: Color = OUTER_OBSTACLE_COLOR if _is_outer_wall(cell, cols, rows) else INNER_OBSTACLE_COLOR
-				var obstacle: StaticBody2D = _create_wall_obstacle(context.obstacles.size(), world_center, cell_size, color)
-				context.obstacles.append(obstacle)
-				context.add_generated_node(obstacle, main_scene)
-			elif tile == "S":
-				context.set_player_spawn_override(world_center)
-			elif tile == "E":
-				context.exit_pos = world_center
-				if context.exit_spawner and is_instance_valid(context.exit_spawner):
-					var exit_size: int = 64
-					var exit_position: Vector2 = world_center - Vector2(exit_size * 0.5, exit_size * 0.5)
-					context.exit_spawner.create_exit_at(exit_position, main_scene)
-					var exit_node: Node = context.exit_spawner.get_exit()
-					if exit_node:
-						context.exit_pos = exit_node.position + Vector2(exit_size * 0.5, exit_size * 0.5)
-			elif tile.begins_with("D_"):
-				var color_code: String = tile.substr(2, tile.length() - 2)
-				var door_color: Color = context.get_group_color(door_index)
-				var door: StaticBody2D = LEVEL_NODE_FACTORY.create_door_node(door_index, 1, false, cell_size, cell_size, door_color)
-				door.position = world_center - Vector2(cell_size * 0.5, cell_size * 0.5)
-				context.doors.append(door)
-				context.add_generated_node(door, main_scene)
-				door_nodes[color_code] = door
-				door_index += 1
-			elif tile.begins_with("K_"):
-				pending_keys.append({
-					"code": tile.substr(2, tile.length() - 2),
-					"center": world_center
-				})
-	for key_data in pending_keys:
-		var color_code: String = key_data.get("code", "R")
-		var door_ref: StaticBody2D = door_nodes.get(color_code, null)
-		if door_ref == null:
-			continue
-		door_ref.initially_open = false
-		var key_center: Vector2 = key_data.get("center", Vector2.ZERO)
-		var key_position: Vector2 = key_center - Vector2(12, 12)
-		var key_node: Area2D = LEVEL_NODE_FACTORY.create_key_node(context.key_items.size(), door_ref, key_position, 1, door_ref.door_color)
-		context.key_items.append(key_node)
-		context.add_generated_node(key_node, main_scene)
-		obstacle_utils.clear_around_position(key_center, cell_size * 0.6)
+	edge.type = type
+	edge.color = color
 
-func _cell_to_world(cell: Vector2i, cell_size: float, offset_x: float, offset_y: float) -> Vector2:
-	return Vector2(offset_x + cell_size * (cell.x + 0.5), offset_y + cell_size * (cell.y + 0.5))
+func _edge_key(a: Vector2i, b: Vector2i) -> String:
+	if a < b:
+		return "%d_%d_%d_%d" % [a.x, a.y, b.x, b.y]
+	return "%d_%d_%d_%d" % [b.x, b.y, a.x, a.y]
 
-func _create_wall_obstacle(index: int, center: Vector2, cell_size: float, color: Color) -> StaticBody2D:
-	var obstacle := StaticBody2D.new()
-	obstacle.name = "KeyLevelObstacle%d" % index
-	obstacle.position = center - Vector2(cell_size * 0.5, cell_size * 0.5)
-	var body := ColorRect.new()
-	body.name = "ObstacleBody"
-	body.offset_right = cell_size
-	body.offset_bottom = cell_size
-	body.color = color
-	obstacle.add_child(body)
-	var collision := CollisionShape2D.new()
-	collision.name = "ObstacleCollision"
-	var shape := RectangleShape2D.new()
-	shape.size = Vector2(cell_size, cell_size)
-	collision.shape = shape
-	collision.position = Vector2(cell_size * 0.5, cell_size * 0.5)
-	obstacle.add_child(collision)
-	return obstacle
+func _reconstruct_path(visited: Dictionary, end_state: Vector3i) -> Array[Vector2i]:
+	var result: Array[Vector2i] = []
+	var current := end_state
+	while visited.has(current):
+		result.push_front(Vector2i(current.x, current.y))
+		var prev: Variant = visited[current]
+		if prev == null:
+			break
+		current = prev
+	return result
 
-func _is_outer_wall(cell: Vector2i, cols: int, rows: int) -> bool:
-	return cell.x == 0 or cell.y == 0 or cell.x == cols - 1 or cell.y == rows - 1
+func _shuffle_with_rng(array: Array, rng: RandomNumberGenerator) -> void:
+	for i in range(array.size() - 1, 0, -1):
+		var j := rng.randi_range(0, i)
+		var temp: Variant = array[i]
+		array[i] = array[j]
+		array[j] = temp
+
+func _draw_edge(parent: Node, a: Vector2i, b: Vector2i, thickness: float, color: Color, is_wall: bool) -> Line2D:
+	var line := Line2D.new()
+	line.width = thickness
+	line.default_color = color
+	line.begin_cap_mode = Line2D.LINE_CAP_ROUND
+	line.end_cap_mode = Line2D.LINE_CAP_ROUND
+	var start_point: Vector2
+	var end_point: Vector2
+	if a.x != b.x:
+		var left: int = min(a.x, b.x)
+		var y: int = a.y
+		start_point = Vector2(left * cell_size, (y + 0.5) * cell_size)
+		end_point = Vector2((left + 1) * cell_size, (y + 0.5) * cell_size)
+	else:
+		var top: int = min(a.y, b.y)
+		var x: int = a.x
+		start_point = Vector2((x + 0.5) * cell_size, top * cell_size)
+		end_point = Vector2((x + 0.5) * cell_size, (top + 1) * cell_size)
+	line.add_point(start_point)
+	line.add_point(end_point)
+	line.z_index = 1 if is_wall else 2
+	parent.add_child(line)
+	return line
+
+func _draw_collision(parent: Node, a: Vector2i, b: Vector2i, thickness: float) -> StaticBody2D:
+	var body := StaticBody2D.new()
+	var shape := CollisionShape2D.new()
+	var rect := RectangleShape2D.new()
+	if a.x != b.x:
+		rect.size = Vector2(cell_size, thickness)
+		body.position = Vector2((min(a.x, b.x) + 0.5) * cell_size, (a.y + 0.5) * cell_size)
+	else:
+		rect.size = Vector2(thickness, cell_size)
+		body.position = Vector2((a.x + 0.5) * cell_size, (min(a.y, b.y) + 0.5) * cell_size)
+	shape.shape = rect
+	body.add_child(shape)
+	parent.add_child(body)
+	return body
+
+func _draw_key(parent: Node, key_spec: KeySpec, key_size: float) -> Area2D:
+	var area := Area2D.new()
+	area.position = Vector2((key_spec.cell.x + 0.5) * cell_size, (key_spec.cell.y + 0.5) * cell_size)
+	var rect := ColorRect.new()
+	rect.color = COLOR_MAP.get(key_spec.color, Color.WHITE)
+	rect.size = Vector2(key_size, key_size)
+	rect.position = Vector2(-key_size * 0.5, -key_size * 0.5)
+	var shape := CollisionShape2D.new()
+	var collider := RectangleShape2D.new()
+	collider.size = Vector2(key_size, key_size)
+	shape.shape = collider
+	shape.position = Vector2.ZERO
+	area.add_child(shape)
+	area.add_child(rect)
+	parent.add_child(area)
+	return area
+
+func _draw_exit(parent: Node, exit_cell: Vector2i) -> ColorRect:
+	var rect := ColorRect.new()
+	rect.color = Color.html("#4caf50")
+	rect.size = Vector2(cell_size, cell_size)
+	rect.position = Vector2(exit_cell.x * cell_size, exit_cell.y * cell_size)
+	parent.add_child(rect)
+	return rect

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -5,152 +5,406 @@ class_name KeyLevelGenerator
 const LOGGER := preload("res://scripts/Logger.gd")
 const LEVEL_UTILS := preload("res://scripts/LevelUtils.gd")
 const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFactory.gd")
-const KEY_PLACEMENT := preload("res://scripts/level_generators/key/KeyPlacementUtils.gd")
-const KEY_RING_LAYOUT := preload("res://scripts/level_generators/key/KeyRingLayoutPlanner.gd")
-const KEY_RING_BARRIERS := preload("res://scripts/level_generators/key/KeyRingBarrierBuilder.gd")
-const KEY_RING_DOORS := preload("res://scripts/level_generators/key/KeyRingDoorSpawner.gd")
-const KEY_RING_SETTINGS := preload("res://scripts/level_generators/key/KeyRingSettings.gd")
+
+const MIN_GRID_SIZE := 12
+const MAX_GRID_SIZE := 20
+const MAX_GENERATION_ATTEMPTS := 32
+const OBSTACLE_RATIO := 0.12
+const COLORS := ["R", "Y", "B", "P"]
+const OUTER_OBSTACLE_COLOR := Color(0.36, 0.17, 0.08, 1.0)
+const INNER_OBSTACLE_COLOR := Color(0.55, 0.55, 0.55, 1.0)
 
 var context
 var obstacle_utils
-var _layout_planner
-var _barrier_builder
-var _door_spawner
+var last_generated_grid: Array = []
+
+var _rng := RandomNumberGenerator.new()
+var _use_custom_seed := false
+var _seed_value := 0
 
 func _init(level_context, obstacle_helper):
 	context = level_context
 	obstacle_utils = obstacle_helper
-	_layout_planner = KEY_RING_LAYOUT.new(context)
-	_barrier_builder = KEY_RING_BARRIERS.new(context)
-	_door_spawner = KEY_RING_DOORS.new(context, obstacle_utils)
+	_rng.randomize()
+
+func set_seed(value: int) -> void:
+	_use_custom_seed = true
+	_seed_value = value
+
+func get_last_generated_grid() -> Array:
+	return last_generated_grid
 
 func generate(main_scene, level: int, player_start_position: Vector2) -> void:
-	var dims = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
-	var level_width: float = float(dims.width)
-	var level_height: float = float(dims.height)
-	var offset = Vector2(dims.offset_x, dims.offset_y)
-	var layout = _layout_planner.create_layout(offset, level_width, level_height, level)
-	var rings: Array = layout.get("rings", [])
-	if rings.is_empty():
-		_generate_legacy_key_level(main_scene, level, player_start_position, offset, level_width, level_height)
+	var dims: Dictionary = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
+	_reset_rng(level)
+	var layout: Dictionary = _build_level_layout(level)
+	if layout.is_empty():
+		LOGGER.log_error("KeyLevelGenerator failed to build solvable layout")
 		return
-	context.exit_spawner.clear_exit()
-	context.coins.clear()
-	var spawn_override: Vector2 = layout.get("spawn", Vector2(offset.x + 90.0, offset.y + level_height * 0.5))
-	_generate_key_level_obstacles(context.current_level_size, main_scene, level, rings, spawn_override)
-	_spawn_ring_wall_obstacles(rings, main_scene)
-	var exit_position: Vector2 = layout.get("exit", Vector2(offset.x + level_width - 160.0, offset.y + level_height * 0.5))
-	context.exit_pos = exit_position
-	_barrier_builder.spawn(rings, main_scene)
-	_door_spawner.spawn(rings, main_scene)
-	context.exit_spawner.create_exit_at(exit_position, main_scene)
-	var exit_node = context.exit_spawner.get_exit()
-	if exit_node:
-		context.exit_pos = exit_node.position
-	obstacle_utils.clear_around_position(context.exit_pos, 110.0)
-	context.set_player_spawn_override(spawn_override)
+	last_generated_grid = layout.get("grid", [])
+	_spawn_from_grid(layout, dims, main_scene)
 
-func _generate_key_level_obstacles(level_size: float, _main_scene, level: int, rings: Array, spawn_override: Vector2) -> void:
-	if context.obstacle_spawner == null or not is_instance_valid(context.obstacle_spawner):
-		LOGGER.log_error("ObstacleSpawner unavailable for key level")
-		return
-	context.obstacles = context.obstacle_spawner.generate_obstacles(level_size, true, _main_scene, level)
-	if context.obstacles.is_empty():
-		return
-	var clearance_rects: Array = _layout_planner.build_clearance_rects(rings)
-	if not clearance_rects.is_empty():
-		obstacle_utils.clear_in_rects(clearance_rects)
-	if spawn_override != Vector2.ZERO:
-		obstacle_utils.clear_around_position(spawn_override, 140.0)
+func _reset_rng(level: int) -> void:
+	if _use_custom_seed:
+		_rng.seed = _seed_value
+	else:
+		_rng.seed = hash([Time.get_ticks_usec(), level, randi()])
 
-func _spawn_ring_wall_obstacles(rings: Array, main_scene) -> void:
-	var created: int = context.obstacles.size()
-	for entry in rings:
-		if typeof(entry) != TYPE_DICTIONARY:
+func _build_level_layout(level: int) -> Dictionary:
+	for attempt in range(MAX_GENERATION_ATTEMPTS):
+		var width: int = _rng.randi_range(MIN_GRID_SIZE, MAX_GRID_SIZE)
+		var height: int = _rng.randi_range(MIN_GRID_SIZE, MAX_GRID_SIZE)
+		var grid: Array = _create_empty_grid(width, height)
+		var start: Vector2i = Vector2i(width / 2, height / 2)
+		var exit_cell: Variant = _choose_exit_cell(width, height, start)
+		if exit_cell == null:
 			continue
-		var ring: Dictionary = entry
-		var door_layouts: Array = ring.get("doors", [])
-		var blocked_walls: Array = []
-		for layout in door_layouts:
-			var wall_index: int = int(layout.get("wall", -1))
-			if wall_index >= 0 and not blocked_walls.has(wall_index):
-				blocked_walls.append(wall_index)
-		var inner_margin: float = max(float(ring.get("inner_margin", KEY_RING_SETTINGS.WALL_THICKNESS + KEY_RING_SETTINGS.KEY_WALL_OFFSET)), 12.0)
-		var wall_thickness: float = float(ring.get("wall_thickness", KEY_RING_SETTINGS.WALL_THICKNESS))
-		var center: Vector2 = ring.get("center", Vector2.ZERO)
-		var top: float = float(ring.get("top", center.y))
-		var bottom: float = float(ring.get("bottom", center.y))
-		var left: float = float(ring.get("left", center.x))
-		var right: float = float(ring.get("right", center.x))
-		var usable_width: float = max(float(ring.get("usable_width", 0.0)), 0.0)
-		var usable_height: float = max(float(ring.get("usable_height", 0.0)), 0.0)
-		if usable_width < 40.0 or usable_height < 40.0:
+		_place_outer_walls(grid)
+		if not _place_internal_obstacles(grid, start, exit_cell):
 			continue
-		var ring_width: float = float(ring.get("width", right - left))
-		var ring_height: float = float(ring.get("height", bottom - top))
-		var horizontal_width: float = _compute_overlap_length(usable_width, ring_width, wall_thickness)
-		var horizontal_height: float = max(wall_thickness * 0.75, 48.0)
-		var vertical_height: float = _compute_overlap_length(usable_height, ring_height, wall_thickness)
-		var vertical_width: float = max(wall_thickness * 0.75, 48.0)
-		if not blocked_walls.has(0):
-			created += 1
-			var top_center = Vector2(center.x, top + inner_margin * 0.35)
-			_create_wall_overlap_obstacle(created, top_center, Vector2(horizontal_width, horizontal_height), main_scene)
-		if not blocked_walls.has(2):
-			created += 1
-			var bottom_center = Vector2(center.x, bottom - inner_margin * 0.35)
-			_create_wall_overlap_obstacle(created, bottom_center, Vector2(horizontal_width, horizontal_height), main_scene)
-		if not blocked_walls.has(1):
-			created += 1
-			var right_center = Vector2(right - inner_margin * 0.35, center.y)
-			_create_wall_overlap_obstacle(created, right_center, Vector2(vertical_width, vertical_height), main_scene)
-		if not blocked_walls.has(3):
-			created += 1
-			var left_center = Vector2(left + inner_margin * 0.35, center.y)
-			_create_wall_overlap_obstacle(created, left_center, Vector2(vertical_width, vertical_height), main_scene)
+		var path: Array = _find_path(grid, start, exit_cell)
+		if path.is_empty():
+			continue
+		var door_count: int = _select_door_count(path.size())
+		if door_count < 2:
+			continue
+		var door_infos: Array = _place_doors_on_path(grid, path, door_count)
+		if door_infos.is_empty():
+			continue
+		var key_infos: Array = _place_keys(grid, start, door_infos, path, exit_cell)
+		if key_infos.is_empty() or key_infos.size() != door_infos.size():
+			continue
+		grid[start.y][start.x] = "S"
+		grid[exit_cell.y][exit_cell.x] = "E"
+		if not _validate_map(grid, start, exit_cell, door_infos, key_infos):
+			continue
+		return {
+			"grid": grid,
+			"start": start,
+			"exit": exit_cell,
+			"doors": door_infos,
+			"keys": key_infos
+		}
+	return {}
 
-func _compute_overlap_length(usable_span: float, total_span: float, wall_thickness: float) -> float:
-	var base: float = max(usable_span * 0.6, min(usable_span, 120.0))
-	var span: float = base + wall_thickness * 0.5
-	var max_span: float = max(total_span - wall_thickness * 0.1, 72.0)
-	return clamp(span, 72.0, max_span)
+func _select_door_count(path_length: int) -> int:
+	var max_pairs: int = min(COLORS.size(), 4)
+	var min_pairs: int = 2
+	var span: int = max(path_length - 6, 1)
+	var target: int = clamp(int(floor(span / 6)), min_pairs, max_pairs)
+	return clamp(_rng.randi_range(min_pairs, max_pairs), min_pairs, target)
 
-func _create_wall_overlap_obstacle(index: int, center: Vector2, size: Vector2, main_scene) -> void:
+func _create_empty_grid(width: int, height: int) -> Array:
+	var result: Array = []
+	for _y in range(height):
+		var row: Array = []
+		for _x in range(width):
+			row.append(".")
+		result.append(row)
+	return result
+
+func _place_outer_walls(grid: Array) -> void:
+	var height: int = grid.size()
+	var width: int = grid[0].size()
+	for x in range(width):
+		grid[0][x] = "#"
+		grid[height - 1][x] = "#"
+	for y in range(height):
+		grid[y][0] = "#"
+		grid[y][width - 1] = "#"
+
+func _choose_exit_cell(width: int, height: int, start: Vector2i) -> Variant:
+	var candidates: Array = []
+	for x in range(2, width - 2):
+		candidates.append(Vector2i(x, 1))
+		candidates.append(Vector2i(x, height - 2))
+	for y in range(2, height - 2):
+		candidates.append(Vector2i(1, y))
+		candidates.append(Vector2i(width - 2, y))
+	while not candidates.is_empty():
+		var index: int = _rng.randi_range(0, candidates.size() - 1)
+		var cell: Vector2i = candidates[index]
+		candidates.remove_at(index)
+		if cell == start:
+			continue
+		return cell
+	return null
+
+func _place_internal_obstacles(grid: Array, start: Vector2i, exit_cell: Vector2i) -> bool:
+	var height: int = grid.size()
+	var width: int = grid[0].size()
+	var interior: Array = []
+	for y in range(1, height - 1):
+		for x in range(1, width - 1):
+			var cell: Vector2i = Vector2i(x, y)
+			if cell == start or cell == exit_cell:
+				continue
+			interior.append(cell)
+	var desired: int = int(ceil(interior.size() * OBSTACLE_RATIO))
+	var attempts: int = 0
+	while attempts < interior.size() and desired > 0:
+		var index: int = _rng.randi_range(0, interior.size() - 1)
+		var cell: Vector2i = interior[index]
+		interior.remove_at(index)
+		var prev: String = String(grid[cell.y][cell.x])
+		grid[cell.y][cell.x] = "#"
+		if _has_path(grid, start, exit_cell):
+			desired -= 1
+		else:
+			grid[cell.y][cell.x] = prev
+		attempts += 1
+	return _has_path(grid, start, exit_cell)
+
+func _has_path(grid: Array, start: Vector2i, goal: Vector2i) -> bool:
+	return not _find_path(grid, start, goal).is_empty()
+
+func _find_path(grid: Array, start: Vector2i, goal: Vector2i) -> Array:
+	var width: int = grid[0].size()
+	var height: int = grid.size()
+	var queue: Array = [start]
+	var came_from: Dictionary = {}
+	came_from[start] = start
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		if cell == goal:
+			return _reconstruct_path(came_from, start, goal)
+		for neighbor in _neighbors(cell, width, height):
+			if came_from.has(neighbor):
+				continue
+			var tile: String = grid[neighbor.y][neighbor.x]
+			if tile == "#":
+				continue
+			came_from[neighbor] = cell
+			queue.append(neighbor)
+	return []
+
+func _reconstruct_path(came_from: Dictionary, start: Vector2i, goal: Vector2i) -> Array:
+	var path: Array = []
+	var current: Vector2i = goal
+	while current != start:
+		path.push_front(current)
+		current = came_from.get(current, start)
+	path.push_front(start)
+	return path
+
+func _neighbors(cell: Vector2i, width: int, height: int) -> Array:
+	var result: Array = []
+	var deltas: Array = [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]
+	for delta in deltas:
+		var next: Vector2i = cell + delta
+		if next.x < 0 or next.x >= width or next.y < 0 or next.y >= height:
+			continue
+		result.append(next)
+	return result
+
+func _place_doors_on_path(grid: Array, path: Array, door_count: int) -> Array:
+	var door_infos: Array = []
+	var step: int = max(2, int(floor(path.size() / float(door_count + 1))))
+	var last_index: int = 1
+	for i in range(door_count):
+		var min_index: int = last_index + 1
+		var max_index: int = path.size() - (door_count - i) * 2
+		if min_index >= max_index:
+			return []
+		var index: int = clamp(int(round(float(i + 1) * float(step))), min_index, max_index)
+		var cell: Vector2i = path[index]
+		var after_cell: Vector2i = path[index + 1]
+		var color_code: String = COLORS[i % COLORS.size()]
+		grid[cell.y][cell.x] = "D_%s" % color_code
+		door_infos.append({
+			"cell": cell,
+			"after": after_cell,
+			"color": color_code,
+			"tile": "D_%s" % color_code
+		})
+		last_index = index
+	return door_infos
+
+func _place_keys(grid: Array, start: Vector2i, door_infos: Array, path: Array, exit_cell: Vector2i) -> Array:
+	var key_infos: Array = []
+	var collected: Dictionary = {}
+	var path_lookup: Dictionary = {}
+	for cell in path:
+		path_lookup[cell] = true
+	var current_start: Vector2i = start
+	for door_info in door_infos:
+		var reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
+		var candidates: Array = []
+		for cell in reachable.keys():
+			if cell == start or cell == exit_cell:
+				continue
+			if path_lookup.has(cell) and _rng.randf() < 0.6:
+				continue
+			var blocked: bool = false
+			for existing in key_infos:
+				if existing.get("cell", Vector2i(-1, -1)) == cell:
+					blocked = true
+					break
+			if blocked:
+				continue
+			if grid[cell.y][cell.x] == "#":
+				continue
+			candidates.append(cell)
+		if candidates.is_empty():
+			candidates = reachable.keys()
+		if candidates.is_empty():
+			return []
+		var chosen: Vector2i = candidates[_rng.randi_range(0, candidates.size() - 1)]
+		var color_code: String = door_info.get("color", "R")
+		collected[color_code] = true
+		key_infos.append({
+			"cell": chosen,
+			"color": color_code,
+			"tile": "K_%s" % color_code
+		})
+		grid[chosen.y][chosen.x] = "K_%s" % color_code
+		var reachable_after: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
+		var after_cell: Vector2i = door_info.get("after", current_start)
+		if not reachable_after.has(after_cell):
+			return []
+		current_start = after_cell
+	return key_infos
+
+func _flood_fill_with_keys(grid: Array, start: Vector2i, collected: Dictionary) -> Dictionary:
+	var width: int = grid[0].size()
+	var height: int = grid.size()
+	var visited: Dictionary = {}
+	var queue: Array = []
+	if not _is_walkable(grid, start, collected):
+		return visited
+	visited[start] = true
+	queue.append(start)
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		for neighbor in _neighbors(cell, width, height):
+			if visited.has(neighbor):
+				continue
+			if not _is_walkable(grid, neighbor, collected):
+				continue
+			visited[neighbor] = true
+			queue.append(neighbor)
+	return visited
+
+func _is_walkable(grid: Array, cell: Vector2i, collected: Dictionary) -> bool:
+	var tile: String = grid[cell.y][cell.x]
+	if tile == "#":
+		return false
+	if tile.begins_with("D_"):
+		var color_code: String = tile.substr(2, tile.length() - 2)
+		return collected.has(color_code)
+	return true
+
+func _validate_map(grid: Array, start: Vector2i, exit_cell: Vector2i, door_infos: Array, key_infos: Array) -> bool:
+	var collected: Dictionary = {}
+	var key_lookup: Dictionary = {}
+	for key_info in key_infos:
+		key_lookup[key_info.get("color", "R")] = key_info.get("cell", Vector2i(-1, -1))
+	var current_start: Vector2i = start
+	for door_info in door_infos:
+		var reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
+		var key_cell: Vector2i = key_lookup.get(door_info.get("color", "R"), Vector2i(-1, -1))
+		if not reachable.has(key_cell):
+			return false
+		var color_code: String = door_info.get("color", "R")
+		collected[color_code] = true
+		var reachable_after: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
+		var after_cell: Vector2i = door_info.get("after", current_start)
+		if not reachable_after.has(after_cell):
+			return false
+		current_start = after_cell
+	var final_reachable: Dictionary = _flood_fill_with_keys(grid, current_start, collected)
+	return final_reachable.has(exit_cell)
+
+func _spawn_from_grid(layout: Dictionary, dims: Dictionary, main_scene) -> void:
+	if context == null:
+		return
+	context.obstacles = []
+	context.doors = []
+	context.key_items = []
+	context.key_barriers = []
+	context.coins = []
+	var grid: Array = layout.get("grid", [])
+	if grid.is_empty():
+		return
+	var rows: int = grid.size()
+	var cols: int = grid[0].size()
+	var cell_size: float = min(dims.width / float(cols), dims.height / float(rows))
+	var offset_x: float = dims.offset_x + (dims.width - cell_size * cols) * 0.5
+	var offset_y: float = dims.offset_y + (dims.height - cell_size * rows) * 0.5
+	var door_nodes: Dictionary = {}
+	var door_index: int = 0
+	var pending_keys: Array = []
+	if context.exit_spawner and is_instance_valid(context.exit_spawner):
+		context.exit_spawner.clear_exit()
+	for y in range(rows):
+		for x in range(cols):
+			var tile: String = grid[y][x]
+			var cell: Vector2i = Vector2i(x, y)
+			var world_center: Vector2 = _cell_to_world(cell, cell_size, offset_x, offset_y)
+			if tile == "#":
+				var color: Color = OUTER_OBSTACLE_COLOR if _is_outer_wall(cell, cols, rows) else INNER_OBSTACLE_COLOR
+				var obstacle: StaticBody2D = _create_wall_obstacle(context.obstacles.size(), world_center, cell_size, color)
+				context.obstacles.append(obstacle)
+				context.add_generated_node(obstacle, main_scene)
+			elif tile == "S":
+				context.set_player_spawn_override(world_center)
+			elif tile == "E":
+				context.exit_pos = world_center
+				if context.exit_spawner and is_instance_valid(context.exit_spawner):
+					var exit_size: int = 64
+					var exit_position: Vector2 = world_center - Vector2(exit_size * 0.5, exit_size * 0.5)
+					context.exit_spawner.create_exit_at(exit_position, main_scene)
+					var exit_node: Node = context.exit_spawner.get_exit()
+					if exit_node:
+						context.exit_pos = exit_node.position + Vector2(exit_size * 0.5, exit_size * 0.5)
+			elif tile.begins_with("D_"):
+				var color_code: String = tile.substr(2, tile.length() - 2)
+				var door_color: Color = context.get_group_color(door_index)
+				var door: StaticBody2D = LEVEL_NODE_FACTORY.create_door_node(door_index, 1, false, cell_size, cell_size, door_color)
+				door.position = world_center - Vector2(cell_size * 0.5, cell_size * 0.5)
+				context.doors.append(door)
+				context.add_generated_node(door, main_scene)
+				door_nodes[color_code] = door
+				door_index += 1
+			elif tile.begins_with("K_"):
+				pending_keys.append({
+					"code": tile.substr(2, tile.length() - 2),
+					"center": world_center
+				})
+	for key_data in pending_keys:
+		var color_code: String = key_data.get("code", "R")
+		var door_ref: StaticBody2D = door_nodes.get(color_code, null)
+		if door_ref == null:
+			continue
+		door_ref.initially_open = false
+		var key_center: Vector2 = key_data.get("center", Vector2.ZERO)
+		var key_position: Vector2 = key_center - Vector2(12, 12)
+		var key_node: Area2D = LEVEL_NODE_FACTORY.create_key_node(context.key_items.size(), door_ref, key_position, 1, door_ref.door_color)
+		context.key_items.append(key_node)
+		context.add_generated_node(key_node, main_scene)
+		obstacle_utils.clear_around_position(key_center, cell_size * 0.6)
+
+func _cell_to_world(cell: Vector2i, cell_size: float, offset_x: float, offset_y: float) -> Vector2:
+	return Vector2(offset_x + cell_size * (cell.x + 0.5), offset_y + cell_size * (cell.y + 0.5))
+
+func _create_wall_obstacle(index: int, center: Vector2, cell_size: float, color: Color) -> StaticBody2D:
 	var obstacle := StaticBody2D.new()
-	obstacle.name = "KeyWallObstacle%d" % index
-	obstacle.position = center - size * 0.5
+	obstacle.name = "KeyLevelObstacle%d" % index
+	obstacle.position = center - Vector2(cell_size * 0.5, cell_size * 0.5)
 	var body := ColorRect.new()
 	body.name = "ObstacleBody"
-	body.offset_right = size.x
-	body.offset_bottom = size.y
-	body.color = KEY_RING_SETTINGS.WALL_OBSTACLE_COLOR
+	body.offset_right = cell_size
+	body.offset_bottom = cell_size
+	body.color = color
 	obstacle.add_child(body)
 	var collision := CollisionShape2D.new()
 	collision.name = "ObstacleCollision"
 	var shape := RectangleShape2D.new()
-	shape.size = size
+	shape.size = Vector2(cell_size, cell_size)
 	collision.shape = shape
-	collision.position = size * 0.5
+	collision.position = Vector2(cell_size * 0.5, cell_size * 0.5)
 	obstacle.add_child(collision)
-	context.obstacles.append(obstacle)
-	context.add_generated_node(obstacle, main_scene)
+	return obstacle
 
-func _generate_legacy_key_level(main_scene, level: int, player_start_position: Vector2, offset: Vector2, level_width: float, level_height: float) -> void:
-	var spawn_y = clamp(player_start_position.y, offset.y + 90.0, offset.y + level_height - 90.0)
-	var spawn_override = Vector2(offset.x + 90.0, spawn_y)
-	_generate_key_level_obstacles(context.current_level_size, main_scene, level, [], spawn_override)
-	context.exit_spawner.clear_exit()
-	context.coins.clear()
-	var fallback_points := KEY_PLACEMENT.sample_far_points(3, offset, level_width, level_height, 220.0)
-	for point in fallback_points:
-		var door = LEVEL_NODE_FACTORY.create_door_node(context.doors.size(), 0, true, 140.0, 48.0, context.get_group_color(context.doors.size()))
-		door.position = Vector2(point.x - 24.0, point.y - 70.0)
-		context.doors.append(door)
-		context.add_generated_node(door, main_scene)
-	var exit_position = Vector2(offset.x + level_width - 140.0, offset.y + level_height * 0.5)
-	context.exit_spawner.create_exit_at(exit_position, main_scene)
-	var exit_node = context.exit_spawner.get_exit()
-	if exit_node:
-		context.exit_pos = exit_node.position
-	obstacle_utils.clear_around_position(context.exit_pos, 110.0)
-	context.set_player_spawn_override(spawn_override)
+func _is_outer_wall(cell: Vector2i, cols: int, rows: int) -> bool:
+	return cell.x == 0 or cell.y == 0 or cell.x == cols - 1 or cell.y == rows - 1

--- a/scripts/level_generators/KeyLevelGenerator.gd
+++ b/scripts/level_generators/KeyLevelGenerator.gd
@@ -8,6 +8,7 @@ const LEVEL_NODE_FACTORY := preload("res://scripts/level_generators/LevelNodeFac
 
 const MIN_GRID_SIZE := 12
 const MAX_GRID_SIZE := 20
+const MIN_CELL_SIZE := 32.0
 const MAX_GENERATION_ATTEMPTS := 32
 const OBSTACLE_RATIO := 0.12
 const COLORS := ["R", "Y", "B", "P"]
@@ -37,7 +38,7 @@ func get_last_generated_grid() -> Array:
 func generate(main_scene, level: int, player_start_position: Vector2) -> void:
 	var dims: Dictionary = LEVEL_UTILS.get_scaled_level_dimensions(context.current_level_size)
 	_reset_rng(level)
-	var layout: Dictionary = _build_level_layout(level)
+	var layout: Dictionary = _build_level_layout(level, dims)
 	if layout.is_empty():
 		LOGGER.log_error("KeyLevelGenerator failed to build solvable layout")
 		return
@@ -50,10 +51,14 @@ func _reset_rng(level: int) -> void:
 	else:
 		_rng.seed = hash([Time.get_ticks_usec(), level, randi()])
 
-func _build_level_layout(level: int) -> Dictionary:
+func _build_level_layout(level: int, dims: Dictionary) -> Dictionary:
+	var max_cols: int = int(floor(dims.width / MIN_CELL_SIZE))
+	var max_rows: int = int(floor(dims.height / MIN_CELL_SIZE))
+	max_cols = max(MIN_GRID_SIZE, min(MAX_GRID_SIZE, max_cols))
+	max_rows = max(MIN_GRID_SIZE, min(MAX_GRID_SIZE, max_rows))
 	for attempt in range(MAX_GENERATION_ATTEMPTS):
-		var width: int = _rng.randi_range(MIN_GRID_SIZE, MAX_GRID_SIZE)
-		var height: int = _rng.randi_range(MIN_GRID_SIZE, MAX_GRID_SIZE)
+		var width: int = _rng.randi_range(MIN_GRID_SIZE, max_cols)
+		var height: int = _rng.randi_range(MIN_GRID_SIZE, max_rows)
 		var grid: Array = _create_empty_grid(width, height)
 		var start: Vector2i = Vector2i(width / 2, height / 2)
 		var exit_cell: Variant = _choose_exit_cell(width, height, start)


### PR DESCRIPTION
## Summary
- replace the key level generator with a seeded, grid-based layout builder that randomizes dimensions, obstacles, and spawn data
- ensure keys and doors are sequenced via BFS reachability checks so each lock blocks later objectives and the exit remains solvable
- instantiate obstacles, doors, keys, and the exit from the generated grid while caching the map for inspection

## Testing
- tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68e40f637d5c8323b174d9c186729583