### PR TITLE
Add 7-stage Challenge Run with stage mutators and centralize level-type metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,15 @@ Select the desired level template in the main menu. Available options:
 | **Maze Complex** | Dense labyrinth that fills the arena with thin wall lines, wide corridors, and multiple branches leading toward a central exit. |
 | **Maze Complex + Coins** | Complex maze variant with additional coin placement tuned for its wider passages and branch density. |
 | **Random** | Picks one of the above templates (including Maze + Keys and the complex variants) each time a new level is generated. |
+| **Challenge Run** | A curated 7-stage gauntlet launched from the main menu. It visits every playable archetype once, adds named stage goals to the HUD, and enables stage-specific Limited Field of View / tug-of-war mutators on later levels. |
 
-When you restart a failed level, the same template is reused. Advancing to the next level rerolls a template if **Random** is selected.
+When you restart a failed level, the same template is reused. Advancing to the next level rerolls a template if **Random** is selected. Challenge Run progresses through **Warmup Cache**, **Key Circuit**, **Lantern Maze**, **Coin Detour**, **Locked Passage**, **Open Labyrinth**, and **Final Vault** so the campaign steadily moves from familiar collection toward restricted-visibility maze pressure.
 
 ## Gameplay Systems
+
+### Challenge Run Mutators
+
+The **Challenge Run** button starts a structured seven-level campaign instead of a random playlist. Each stage is named in the level-progress HUD, and later stages can override the menu's Limited Field of View setting or enable the tug-of-war movement drift that gently pushes the player sideways. This keeps practice mode predictable while giving the challenge route a stronger escalation arc.
 
 ### Speed Boost & Ghost Trail
 

--- a/scripts/GameState.gd
+++ b/scripts/GameState.gd
@@ -2,17 +2,28 @@ class_name GameState
 extends Node
 
 const GameLogger = preload("res://scripts/Logger.gd")
-
+const MAX_CAMPAIGN_LEVELS := 7
+const BASE_LEVEL_SIZE := 0.85
+const MAX_LEVEL_SIZE := 2.0
 # Game state management
 enum GameStateType {PLAYING, WON, LOST}
 enum LevelType {OBSTACLES_COINS, KEYS, MAZE, MAZE_COINS, MAZE_KEYS, MAZE_COMPLEX, MAZE_COMPLEX_COINS, RANDOM, CHALLENGE}
+const CHALLENGE_STAGE_CONFIGS := [
+	{"name": "Warmup Cache", "type": LevelType.OBSTACLES_COINS, "lfov": false, "tug": false},
+	{"name": "Key Circuit", "type": LevelType.KEYS, "lfov": false, "tug": false},
+	{"name": "Lantern Maze", "type": LevelType.MAZE, "lfov": true, "tug": false},
+	{"name": "Coin Detour", "type": LevelType.MAZE_COINS, "lfov": true, "tug": false},
+	{"name": "Locked Passage", "type": LevelType.MAZE_KEYS, "lfov": true, "tug": true},
+	{"name": "Open Labyrinth", "type": LevelType.MAZE_COMPLEX, "lfov": false, "tug": true},
+	{"name": "Final Vault", "type": LevelType.MAZE_COMPLEX_COINS, "lfov": true, "tug": true},
+]
 var current_state = GameStateType.PLAYING
 
 # Progressive level scaling
 var current_level = 1
 var victories = 0
-var current_level_size = 0.85 # Start at 85% of full size
-var max_level_size = 2.0 # 200% of base size
+var current_level_size = BASE_LEVEL_SIZE # Start at 85% of full size
+var max_level_size = MAX_LEVEL_SIZE # 200% of base size
 var level_size_increment = 0.0
 
 # Game configuration
@@ -31,10 +42,12 @@ var current_level_type: LevelType = LevelType.OBSTACLES_COINS
 var challenge_sequence: Array = []
 var challenge_stage_index: int = 0
 var challenge_lfov_flags: Array = []
+var challenge_tug_flags: Array = []
+var challenge_stage_names: Array = []
 
 func _ready():
 	# Calculate level size increment
-	level_size_increment = (max_level_size - current_level_size) / 7.0
+	level_size_increment = (max_level_size - current_level_size) / float(MAX_CAMPAIGN_LEVELS)
 	if Engine.has_meta("level_type_selection"):
 		var stored_type = int(Engine.get_meta("level_type_selection"))
 		if stored_type >= 0 and stored_type <= LevelType.CHALLENGE:
@@ -45,13 +58,13 @@ func reset_to_start():
 	current_level = 1
 	victories = 0
 	current_state = GameStateType.PLAYING
-	current_level_size = 0.85
+	current_level_size = BASE_LEVEL_SIZE
 	challenge_stage_index = 0
 	_refresh_level_type(true)
 
 func advance_level():
 	# Check if we've completed all levels BEFORE incrementing
-	if current_level >= 7:
+	if current_level >= MAX_CAMPAIGN_LEVELS:
 		reset_to_start()
 		return true # Indicates we've completed all levels
 
@@ -59,10 +72,10 @@ func advance_level():
 	victories += 1
 
 	# Update level size
-	current_level_size = 0.85 + (victories * level_size_increment)
+	current_level_size = BASE_LEVEL_SIZE + (victories * level_size_increment)
 	current_level_size = min(current_level_size, max_level_size)
 	if selected_level_type == LevelType.CHALLENGE:
-		challenge_stage_index = clamp(current_level - 1, 0, 6)
+		challenge_stage_index = clamp(current_level - 1, 0, MAX_CAMPAIGN_LEVELS - 1)
 	_refresh_level_type(true)
 
 	return false
@@ -70,17 +83,22 @@ func advance_level():
 func drop_progress_on_loss():
 	current_level = 1
 	victories = 0
-	current_level_size = 0.85
+	current_level_size = BASE_LEVEL_SIZE
 	challenge_stage_index = 0
 	_refresh_level_type(true)
 
 func get_level_progress_text() -> String:
-	return "Level: " + str(current_level) + "/7"
+	var base_text := "Level: " + str(current_level) + "/" + str(MAX_CAMPAIGN_LEVELS)
+	if selected_level_type == LevelType.CHALLENGE:
+		var stage_name := get_current_challenge_stage_name()
+		if stage_name != "":
+			base_text += " - " + stage_name
+	return base_text
 
 func get_next_level_size() -> float:
-	if current_level >= 7:
-		return 0.85 # Reset to start
-	return 0.85 + (victories * level_size_increment)
+	if current_level >= MAX_CAMPAIGN_LEVELS:
+		return BASE_LEVEL_SIZE # Reset to start
+	return BASE_LEVEL_SIZE + (victories * level_size_increment)
 
 func is_game_active() -> bool:
 	return current_state == GameStateType.PLAYING
@@ -97,7 +115,7 @@ func set_level_type(new_type: LevelType):
 		_generate_challenge_sequence()
 		challenge_stage_index = 0
 	_refresh_level_type(true)
-	GameLogger.log_game_mode("Level type selection updated to %s" % _get_level_type_label(selected_level_type))
+	GameLogger.log_game_mode("Level type selection updated to %s" % get_level_type_label(selected_level_type))
 
 func get_current_level_type() -> LevelType:
 	return current_level_type
@@ -110,13 +128,13 @@ func set_tug_of_war_enabled(enabled: bool) -> void:
 func update_tug_of_war_force(delta: float) -> void:
 	if not tug_of_war_enabled:
 		return
-	
+
 	# Simple tug of war: gradually shift force based on player position
 	# This is a simplified implementation - in a real game you'd have more complex logic
 	var random_factor = randf_range(-0.1, 0.1)
 	tug_of_war_force += random_factor * delta
 	tug_of_war_force = clamp(tug_of_war_force, -1.0, 1.0)
-	
+
 	# Gradually return to center
 	tug_of_war_force *= 0.95
 
@@ -135,25 +153,35 @@ func _refresh_level_type(force_new: bool = false):
 			current_level_type = LevelType.OBSTACLES_COINS
 		else:
 			current_level_type = challenge_sequence[challenge_stage_index]
-		# Enforce LFOV per challenge stage regardless of main menu setting
-		if challenge_lfov_flags.size() == challenge_sequence.size():
-			var lfov: bool = bool(challenge_lfov_flags[challenge_stage_index])
-			Engine.set_meta("limited_field_of_view", lfov)
+		_apply_challenge_stage_mutators()
 	elif selected_level_type == LevelType.RANDOM:
+		set_tug_of_war_enabled(false)
 		if force_new or current_level_type == LevelType.RANDOM:
 			current_level_type = _pick_random_level_type()
 	else:
+		set_tug_of_war_enabled(false)
 		current_level_type = selected_level_type
 	if previous_type != current_level_type:
-		GameLogger.log_game_mode("Current level type set to %s" % _get_level_type_label(current_level_type))
+		GameLogger.log_game_mode("Current level type set to %s" % get_level_type_label(current_level_type))
 
 func _pick_random_level_type() -> LevelType:
-	var options: Array = [LevelType.OBSTACLES_COINS, LevelType.KEYS, LevelType.MAZE, LevelType.MAZE_COINS, LevelType.MAZE_KEYS, LevelType.MAZE_COMPLEX, LevelType.MAZE_COMPLEX_COINS]
+	var options: Array = get_playable_level_types()
 	if options.is_empty():
 		return LevelType.OBSTACLES_COINS
 	return options[randi() % options.size()]
 
-func _get_level_type_label(level_type: LevelType) -> String:
+static func get_playable_level_types() -> Array:
+	return [
+		LevelType.OBSTACLES_COINS,
+		LevelType.KEYS,
+		LevelType.MAZE,
+		LevelType.MAZE_COINS,
+		LevelType.MAZE_KEYS,
+		LevelType.MAZE_COMPLEX,
+		LevelType.MAZE_COMPLEX_COINS,
+	]
+
+static func get_level_type_label(level_type: int) -> String:
 	match level_type:
 		LevelType.OBSTACLES_COINS:
 			return "Obstacles + Coins"
@@ -176,37 +204,30 @@ func _get_level_type_label(level_type: LevelType) -> String:
 	return str(level_type)
 
 func _generate_challenge_sequence() -> void:
-	# Define 7 stages and whether each should use LFOV (true) during challenge
-	var types: Array = [
-		LevelType.KEYS, # no LFOV
-		LevelType.MAZE, # LFOV
-		LevelType.MAZE_COINS, # LFOV
-		LevelType.MAZE_KEYS, # LFOV
-		LevelType.MAZE_COMPLEX, # no LFOV
-		LevelType.MAZE_COMPLEX, # LFOV enforced
-		LevelType.MAZE_COMPLEX_COINS # no LFOV
-	]
-	var lfov: Array = [
-		false,
-		true,
-		true,
-		true,
-		false,
-		true,
-		false
-	]
-	# Shuffle indices to keep pairing between type and LFOV
-	var indices: Array = []
-	for i in range(types.size()):
-		indices.append(i)
-	indices.shuffle()
 	var seq: Array = []
 	var flags: Array = []
-	for i in indices:
-		seq.append(types[i])
-		flags.append(lfov[i])
+	var tug_flags: Array = []
+	var stage_names: Array = []
+	for stage in CHALLENGE_STAGE_CONFIGS:
+		seq.append(stage["type"])
+		flags.append(bool(stage["lfov"]))
+		tug_flags.append(bool(stage["tug"]))
+		stage_names.append(str(stage["name"]))
 	challenge_sequence = seq
 	challenge_lfov_flags = flags
+	challenge_tug_flags = tug_flags
+	challenge_stage_names = stage_names
+
+func _apply_challenge_stage_mutators() -> void:
+	var has_lfov_flag := challenge_lfov_flags.size() == challenge_sequence.size()
+	var has_tug_flag := challenge_tug_flags.size() == challenge_sequence.size()
+	if has_lfov_flag:
+		var lfov: bool = bool(challenge_lfov_flags[challenge_stage_index])
+		Engine.set_meta("limited_field_of_view", lfov)
+	if has_tug_flag:
+		set_tug_of_war_enabled(bool(challenge_tug_flags[challenge_stage_index]))
+	else:
+		set_tug_of_war_enabled(false)
 
 func get_current_challenge_lfov() -> bool:
 	if selected_level_type != LevelType.CHALLENGE:
@@ -215,3 +236,19 @@ func get_current_challenge_lfov() -> bool:
 		return Engine.has_meta("limited_field_of_view") and bool(Engine.get_meta("limited_field_of_view"))
 	var idx = clamp(current_level - 1, 0, challenge_lfov_flags.size() - 1)
 	return bool(challenge_lfov_flags[idx])
+
+func get_current_challenge_tug_enabled() -> bool:
+	if selected_level_type != LevelType.CHALLENGE:
+		return tug_of_war_enabled
+	if challenge_tug_flags.size() != challenge_sequence.size():
+		return false
+	var idx = clamp(current_level - 1, 0, challenge_tug_flags.size() - 1)
+	return bool(challenge_tug_flags[idx])
+
+func get_current_challenge_stage_name() -> String:
+	if selected_level_type != LevelType.CHALLENGE:
+		return ""
+	if challenge_stage_names.size() != challenge_sequence.size():
+		return ""
+	var idx = clamp(current_level - 1, 0, challenge_stage_names.size() - 1)
+	return str(challenge_stage_names[idx])

--- a/scripts/MainMenu.gd
+++ b/scripts/MainMenu.gd
@@ -13,17 +13,15 @@ const GameState = preload("res://scripts/GameState.gd")
 
 var difficulty_names = ["child", "regular", "hard", "challenge"]
 var current_difficulty_index = 1 # Start with "regular"
-var level_type_options = [
-	{"name": "Obstacles + Coins", "type": GameState.LevelType.OBSTACLES_COINS},
-	{"name": "Keys", "type": GameState.LevelType.KEYS},
-	{"name": "Maze", "type": GameState.LevelType.MAZE},
-	{"name": "Maze + Coins", "type": GameState.LevelType.MAZE_COINS},
-	{"name": "Maze + Keys", "type": GameState.LevelType.MAZE_KEYS},
-	{"name": "Maze complex", "type": GameState.LevelType.MAZE_COMPLEX},
-	{"name": "Maze complex + Coins", "type": GameState.LevelType.MAZE_COMPLEX_COINS},
-	{"name": "Random", "type": GameState.LevelType.RANDOM},
-]
+var level_type_options = _build_level_type_options()
 var current_level_type_index = 0
+
+func _build_level_type_options() -> Array:
+	var options: Array = []
+	for level_type in GameState.get_playable_level_types():
+		options.append({"name": GameState.get_level_type_label(level_type), "type": level_type})
+	options.append({"name": GameState.get_level_type_label(GameState.LevelType.RANDOM), "type": GameState.LevelType.RANDOM})
+	return options
 
 func _ready():
 	# Connect signals

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -89,7 +89,7 @@ func _physics_process(delta):
 
 	# Apply tug of war force if enabled
 	var tug_force = Vector2.ZERO
-	var game_state = get_node("/root/Main/GameState")
+	var game_state = get_node_or_null("/root/Main/GameState")
 	if game_state and game_state.has_method("get_tug_of_war_force"):
 		tug_force = game_state.get_tug_of_war_force()
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ This folder contains all gameplay scripts for the 2D mini game. The modules belo
 
 ## Core Gameplay Orchestration
 - **`Main.gd`** – Root scene controller that wires together the player, UI labels, timers, and spawners. It instantiates the dedicated controllers under `scripts/main/` to manage UI, level lifecycle, game flow, and statistics logging. The scene triggers `generate_new_level()` on start or after wins, connects run-time signals (coin pickups, exit activation, restart/menu buttons), and keeps authoritative counters for coins, keys, and timers while coordinating with `GameState` and `TimerManager`.
-- **`GameState.gd`** – Authoritative store for game progression. It tracks the current level, chosen level type, state (playing / won / lost), and tuning flags (obstacle & coin toggles, exit distance, coverage). `Main.gd` reads these values when preparing each level and updates them when the player wins or loses.
+- **`GameState.gd`** – Authoritative store for game progression. It tracks the current level, chosen level type, state (playing / won / lost), and tuning flags (obstacle & coin toggles, exit distance, coverage). It also owns shared level-type labels plus the Challenge Run sequence/mutators so menus, logging, and HUD text stay consistent. `Main.gd` reads these values when preparing each level and updates them when the player wins or loses.
 - **`TimerManager.gd`** – Central difficulty balancer. After every generation `Main.gd` calls `calculate_level_time()` to compute the allowed time based on difficulty presets, distance to coins and exit, recent player surplus, and level-type heuristics. It also records time left at level completion through `register_level_result()` for future adjustments.
 
 ### Main Scene Controllers (`scripts/main/`)
@@ -36,7 +36,7 @@ This folder contains all gameplay scripts for the 2D mini game. The modules belo
 - **`SmoothCamera.gd`** – Camera2D that follows the player with velocity-based look-ahead and lerped movement to keep the action centered.
 
 ## UI & Entry Points
-- **`MainMenu.gd`** – Front-end menu that sets the difficulty on `TimerManager`, persists the preferred level type via `Engine` metadata, and transitions into the main scene.
+- **`MainMenu.gd`** – Front-end menu that builds practice-mode level choices from `GameState`, sets the difficulty on `TimerManager`, persists the preferred level type via `Engine` metadata, and transitions into the main scene or Challenge Run.
 - **HUD nodes managed by `UIController.gd`** – Labels, buttons, and key indicators updated through the controller to reflect timer countdowns, coin totals, key status, level progress, and win/lose states.
 
 ## State, Timing, and Metrics Flow

--- a/scripts/main/GameFlowController.gd
+++ b/scripts/main/GameFlowController.gd
@@ -60,9 +60,9 @@ func trigger_level_win() -> void:
 		main.timer.timeout.disconnect(main._on_timer_timeout)
 	if statistics_logger:
 		statistics_logger.log_level_statistics()
-	if main.game_state.current_level >= 7:
+	if main.game_state.current_level >= GAME_STATE.MAX_CAMPAIGN_LEVELS:
 		ui_controller.set_restart_button_text("Start all over again?")
-		LOGGER.log_game_mode("All 7 levels completed; awaiting restart")
+		LOGGER.log_game_mode("All %d levels completed; awaiting restart" % GAME_STATE.MAX_CAMPAIGN_LEVELS)
 		main.prevent_game_over = true
 		return
 	ui_controller.set_restart_button_text("Continue")
@@ -118,7 +118,7 @@ func handle_restart_pressed() -> void:
 			main.player.reset_speed_boost()
 	level_controller.clear_level_objects()
 	await main.get_tree().process_frame
-	if main.game_state.current_level > 7:
+	if main.game_state.current_level > GAME_STATE.MAX_CAMPAIGN_LEVELS:
 		main.game_state.reset_to_start()
 		LOGGER.log_game_mode("Level exceeded cap during restart; reset to %d" % main.game_state.current_level)
 	if not main.prevent_game_over:

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -7,16 +7,6 @@ const GAME_STATE := preload("res://scripts/GameState.gd")
 const LEVEL_OBJECT_BINDER := preload("res://scripts/main/level/LevelObjectBinder.gd")
 const LEVEL_GENERATION_SERVICE := preload("res://scripts/main/level/LevelGenerationService.gd")
 
-const LEVEL_TYPE_LABELS := [
-	"Obstacles+Coins",
-	"Keys",
-	"Maze",
-	"Maze+Coins",
-	"Maze+Keys",
-	"Random",
-	"Challenge"
-]
-
 var main = null
 var ui_controller = null
 var game_flow_controller = null
@@ -41,7 +31,7 @@ func set_game_flow_controller(controller) -> void:
 
 func generate_new_level() -> void:
 	main.level_initializing = true
-	if main.game_state.current_level > 7:
+	if main.game_state.current_level > GAME_STATE.MAX_CAMPAIGN_LEVELS:
 		main.game_state.reset_to_start()
 		LOGGER.log_game_mode("Level exceeded cap, reset to level %d" % main.game_state.current_level)
 	var level_type: int = main.game_state.get_current_level_type()
@@ -158,5 +148,4 @@ func get_active_coins() -> Array[Area2D]:
 	return coins
 
 func _log_level_type(level_type: int) -> void:
-	var label: String = LEVEL_TYPE_LABELS[level_type] if level_type < LEVEL_TYPE_LABELS.size() else str(level_type)
-	LOGGER.log_game_mode("Preparing level type: %s" % label)
+	LOGGER.log_game_mode("Preparing level type: %s" % GAME_STATE.get_level_type_label(level_type))

--- a/tests/unit/test_game_state.gd
+++ b/tests/unit/test_game_state.gd
@@ -75,8 +75,8 @@ func test_challenge_sequence_cycles_modes() -> void:
 	var state := _make_state()
 	state.set_level_type(GameState.LevelType.CHALLENGE)
 	assert_eq(state.selected_level_type, GameState.LevelType.CHALLENGE)
-	assert_eq(state.challenge_sequence.size(), 7)
-	var allowed := [GameState.LevelType.OBSTACLES_COINS, GameState.LevelType.KEYS, GameState.LevelType.MAZE, GameState.LevelType.MAZE_COINS, GameState.LevelType.MAZE_KEYS, GameState.LevelType.MAZE_COMPLEX, GameState.LevelType.MAZE_COMPLEX_COINS]
+	assert_eq(state.challenge_sequence.size(), GameState.MAX_CAMPAIGN_LEVELS)
+	var allowed := GameState.get_playable_level_types()
 	for mode in state.challenge_sequence:
 		assert_true(allowed.has(mode))
 	var first_mode := state.get_current_level_type()
@@ -85,3 +85,28 @@ func test_challenge_sequence_cycles_modes() -> void:
 	assert_true(allowed.has(first_mode))
 	assert_true(allowed.has(next_mode))
 	state.free()
+
+func test_challenge_sequence_has_stage_names_and_mutators() -> void:
+	var state := _make_state()
+	state.set_level_type(GameState.LevelType.CHALLENGE)
+	assert_eq(state.challenge_lfov_flags.size(), GameState.MAX_CAMPAIGN_LEVELS)
+	assert_eq(state.challenge_tug_flags.size(), GameState.MAX_CAMPAIGN_LEVELS)
+	assert_eq(state.challenge_stage_names.size(), GameState.MAX_CAMPAIGN_LEVELS)
+	assert_eq(state.get_current_challenge_stage_name(), "Warmup Cache")
+	assert_false(state.get_current_challenge_lfov())
+	assert_false(state.get_current_challenge_tug_enabled())
+	assert_eq(state.get_level_progress_text(), "Level: 1/7 - Warmup Cache")
+	state.current_level = 5
+	state._refresh_level_type(true)
+	assert_eq(state.get_current_level_type(), GameState.LevelType.MAZE_KEYS)
+	assert_eq(state.get_current_challenge_stage_name(), "Locked Passage")
+	assert_true(state.get_current_challenge_lfov())
+	assert_true(state.get_current_challenge_tug_enabled())
+	assert_true(state.tug_of_war_enabled)
+	state.set_level_type(GameState.LevelType.MAZE)
+	assert_false(state.tug_of_war_enabled)
+	state.free()
+
+func test_level_type_labels_cover_complex_modes() -> void:
+	assert_eq(GameState.get_level_type_label(GameState.LevelType.MAZE_COMPLEX), "Maze complex")
+	assert_eq(GameState.get_level_type_label(GameState.LevelType.MAZE_COMPLEX_COINS), "Maze complex + Coins")


### PR DESCRIPTION
### Motivation
- Provide a structured "Challenge Run" campaign that visits every playable archetype with named stages to make a predictable escalation route. 
- Expose stage-specific mutators (Limited Field of View and tug-of-war drift) so later challenge stages can change gameplay without ad-hoc checks scattered around the code. 
- Centralize level-type labels and playable-type list so menus, logging and generation use a single source of truth. 

### Description
- Reworked `scripts/GameState.gd` to add constants `MAX_CAMPAIGN_LEVELS`, `BASE_LEVEL_SIZE`, `MAX_LEVEL_SIZE`, a `CHALLENGE_STAGE_CONFIGS` table and support arrays for `challenge_lfov_flags`, `challenge_tug_flags` and `challenge_stage_names`, plus new helpers `get_playable_level_types()` and `get_level_type_label()` and `_apply_challenge_stage_mutators()`; challenge stage name is shown in `get_level_progress_text()`. 
- Updated `scripts/MainMenu.gd` to dynamically build the practice-level options from `GameState.get_playable_level_types()` and `GameState.get_level_type_label()` instead of a hardcoded list. 
- Replaced hardcoded campaign-size checks with `GAME_STATE.MAX_CAMPAIGN_LEVELS` in `scripts/main/GameFlowController.gd` and `scripts/main/LevelController.gd`, and switched logging in `LevelController` to use `GAME_STATE.get_level_type_label()`. 
- Made player code more robust by using `get_node_or_null("/root/Main/GameState")` when querying tug-of-war to avoid errors when the node is missing. 
- Removed the redundant `LEVEL_TYPE_LABELS` array and centralized labels in `GameState`. 
- Documentation updates: `README.md` and `scripts/README.md` now describe the `Challenge Run` and its mutators. 
- Tests: expanded `tests/unit/test_game_state.gd` to validate challenge sequencing, stage names, LFOV/tug mutators and labels. 

### Testing
- Ran the full unit test suite with `./tests/run_tests.sh` and all tests passed: "All 79 tests passed.". 
- The test run also exercised level generation and main systems and produced no failing suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0549b8fc83239eb33c90fb4afedc)