### PR TITLE
Add pause menu and coin/key time bonuses with UI and config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Mini 2D Game is a top-down arena crawler built with Godot 4. Collect coins, mana
 
 1. Open the project in the Godot editor (`mini_2d_game/project.godot`).
 2. Run the project from the editor or export it for your target platform.
-3. Use the main menu to choose a difficulty and level type, then press **Start Game**.
+3. Use the main menu to choose a difficulty and level type, then press **Start Practice** or **Challenge Run**.
 
 ## Controls
 
 - `W`, `A`, `S`, `D` or arrow keys  move the cube
-- `Esc`  return to the main menu
+- `Esc` – pause or resume the active level
 
-Collecting a coin grants a temporary speed boost that now decays smoothly back to the base speed. While boosted, the cube leaves a ghost trail whose length reflects the remaining boost strength.
+Collecting a coin grants a temporary speed boost and a small time bonus that now decays smoothly back to the base speed. Keys also add emergency time so locked routes reward exploration. While boosted, the cube leaves a ghost trail whose length reflects the remaining boost strength.
 
 ## Level Types
 
@@ -40,6 +40,14 @@ When you restart a failed level, the same template is reused. Advancing to the n
 
 ## Gameplay Systems
 
+### Pause & Level Flow
+
+The run starts from the main menu and level completion presents a **Continue** action before generating the next stage. Pressing `Esc` during active gameplay opens the pause overlay, where you can resume, abandon the current run back to the main menu, or quit the game entirely.
+
+### Time Bonus Pickups
+
+Coins now add a configurable time bonus in addition to speed boosts, and keys add a larger rescue bonus for routes with locked doors. These bonuses are shown in the HUD with a short floating message and are configured in `config/game.cfg` via `coin_time_bonus` and `key_time_bonus`.
+
 ### Challenge Run Mutators
 
 The **Challenge Run** button starts a structured seven-level campaign instead of a random playlist. Each stage is named in the level-progress HUD, and later stages can override the menu's Limited Field of View setting or enable the tug-of-war movement drift that gently pushes the player sideways. This keeps practice mode predictable while giving the challenge route a stronger escalation arc.
@@ -50,11 +58,12 @@ The boost granted by coins is now configurable and fades out gradually instead o
 
 Edit `config/game.cfg` to tweak these values:
 
-- `speed_boost_multiplier`  bonus applied per coin (default `1.5`).
+- `speed_boost_multiplier`  bonus applied per coin (default `1.2`).
 - `speed_boost_decay_time`  seconds for a single coin's boost to fade.
 - `speed_boost_max_stacks`  how many boosts can stack before clamping.
 - `ghost_base_lifetime` / `ghost_extra_lifetime`  minimum and extra trail lifetime.
-- `ghost_spawn_interval` / `ghost_spawn_interval_min`  spawn cadence range.
+- `ghost_spawn_interval` / `ghost_spawn_interval_min` – spawn cadence range.
+- `coin_time_bonus` / `key_time_bonus` – seconds returned to the timer when collecting coins or keys.
 
 ### Coin Placement Safety
 

--- a/config/game.cfg
+++ b/config/game.cfg
@@ -8,3 +8,6 @@ ghost_base_lifetime=0.25
 ghost_extra_lifetime=0.7
 ghost_spawn_interval=0.08
 ghost_spawn_interval_min=0.02
+
+coin_time_bonus=1.5
+key_time_bonus=2.0

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -367,6 +367,65 @@ offset_right = 100.0
 offset_bottom = 60.0
 text = "Restart"
 
+[node name="BonusLabel" type="Label" parent="UI"]
+visible = false
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = -320.0
+offset_right = 260.0
+offset_bottom = -280.0
+text = "+1.5s"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="PauseOverlay" type="ColorRect" parent="UI"]
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 0.68)
+
+[node name="PausePanel" type="PanelContainer" parent="UI/PauseOverlay"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -170.0
+offset_top = -140.0
+offset_right = 170.0
+offset_bottom = 140.0
+
+[node name="PauseVBox" type="VBoxContainer" parent="UI/PauseOverlay/PausePanel"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="PauseTitle" type="Label" parent="UI/PauseOverlay/PausePanel/PauseVBox"]
+layout_mode = 2
+text = "Paused"
+horizontal_alignment = 1
+
+[node name="PauseHint" type="Label" parent="UI/PauseOverlay/PausePanel/PauseVBox"]
+layout_mode = 2
+text = "Take a breath, then continue the run or leave safely."
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="ResumeButton" type="Button" parent="UI/PauseOverlay/PausePanel/PauseVBox"]
+layout_mode = 2
+text = "Continue"
+
+[node name="PauseMenuButton" type="Button" parent="UI/PauseOverlay/PausePanel/PauseVBox"]
+layout_mode = 2
+text = "Back to Main Menu"
+
+[node name="PauseQuitButton" type="Button" parent="UI/PauseOverlay/PausePanel/PauseVBox"]
+layout_mode = 2
+text = "Exit Game"
+
 [node name="Timer" type="Timer" parent="."]
 wait_time = 30.0
 one_shot = true

--- a/scenes/MainMenu.tscn
+++ b/scenes/MainMenu.tscn
@@ -24,9 +24,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -200.0
-offset_top = -150.0
+offset_top = -210.0
 offset_right = 200.0
-offset_bottom = 150.0
+offset_bottom = 210.0
 
 [node name="Title" type="Label" parent="VBoxContainer"]
 layout_mode = 2
@@ -34,9 +34,15 @@ text = "Mini 2D Game"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="MenuHint" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Pick a mode, collect bonuses, find the exit, and press Esc to pause."
+horizontal_alignment = 1
+autowrap_mode = 3
+
 [node name="PracticeButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
-text = "Practice"
+text = "Start Practice"
 
 [node name="ChallengeButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -20,6 +20,11 @@ const GAME_STATE := preload("res://scripts/GameState.gd")
 @onready var win_label: Label = $UI/WinLabel
 @onready var restart_button: Button = $UI/RestartButton
 @onready var menu_button: Button = $UI/MenuButton
+@onready var bonus_label: Label = $UI/BonusLabel
+@onready var pause_overlay: Control = $UI/PauseOverlay
+@onready var resume_button: Button = $UI/PauseOverlay/PausePanel/PauseVBox/ResumeButton
+@onready var pause_menu_button: Button = $UI/PauseOverlay/PausePanel/PauseVBox/PauseMenuButton
+@onready var pause_quit_button: Button = $UI/PauseOverlay/PausePanel/PauseVBox/PauseQuitButton
 @onready var key_container: Control = $UI/KeyContainer
 @onready var key_status_container: Control = $UI/KeyContainer/KeyStatus
 @onready var door_container: Control = $UI/DoorContainer
@@ -42,6 +47,9 @@ var exit: Area2D = null
 var prevent_game_over: bool = false
 var level_start_time: float = 0.0
 var level_initializing: bool = false
+var is_paused: bool = false
+@export var coin_time_bonus: float = 1.5
+@export var key_time_bonus: float = 2.0
 
 var ui_controller: UI_CONTROLLER = null
 var level_controller: LEVEL_CONTROLLER = null
@@ -64,7 +72,12 @@ func _ready() -> void:
 		door_container,
 		door_status_container,
 		speed_label,
-		path_indicator_label
+		path_indicator_label,
+		pause_overlay,
+		resume_button,
+		pause_menu_button,
+		pause_quit_button,
+		bonus_label
 	)
 	level_controller = LEVEL_CONTROLLER.new()
 	level_controller.setup(self, ui_controller)
@@ -76,6 +89,10 @@ func _ready() -> void:
 	timer.timeout.connect(_on_timer_timeout)
 	restart_button.pressed.connect(_on_restart_pressed)
 	menu_button.pressed.connect(_on_menu_pressed)
+	resume_button.pressed.connect(_on_resume_pressed)
+	pause_menu_button.pressed.connect(_on_menu_pressed)
+	pause_quit_button.pressed.connect(_on_quit_pressed)
+	_load_gameplay_config()
 	statistics_logger.init_logging()
 	level_controller.generate_new_level()
 	ui_controller.update_timer_display(game_time)
@@ -85,7 +102,9 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	if Input.is_action_just_pressed("ui_cancel"):
-		get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+		_toggle_pause_menu()
+	if is_paused:
+		return
 	if not game_state.is_game_active():
 		return
 	if level_initializing:
@@ -126,3 +145,37 @@ func _on_restart_pressed() -> void:
 func _on_menu_pressed() -> void:
 	prevent_game_over = false
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+func _load_gameplay_config() -> void:
+	var cfg := ConfigFile.new()
+	var err := cfg.load("res://config/game.cfg")
+	if err != OK:
+		return
+	coin_time_bonus = float(cfg.get_value("gameplay", "coin_time_bonus", coin_time_bonus))
+	key_time_bonus = float(cfg.get_value("gameplay", "key_time_bonus", key_time_bonus))
+
+func _toggle_pause_menu() -> void:
+	if not game_state.is_game_active():
+		return
+	if is_paused:
+		_resume_game()
+	else:
+		_pause_game()
+
+func _pause_game() -> void:
+	is_paused = true
+	if player and is_instance_valid(player):
+		player.set_physics_process(false)
+	ui_controller.show_pause_menu()
+
+func _resume_game() -> void:
+	is_paused = false
+	if player and is_instance_valid(player) and game_state.is_game_active():
+		player.set_physics_process(true)
+	ui_controller.hide_pause_menu()
+
+func _on_resume_pressed() -> void:
+	_resume_game()
+
+func _on_quit_pressed() -> void:
+	get_tree().quit()

--- a/scripts/main/LevelController.gd
+++ b/scripts/main/LevelController.gd
@@ -93,6 +93,7 @@ func handle_coin_collected(body: Node, coin: Area2D) -> void:
 		if main.player and is_instance_valid(main.player):
 			if main.player.has_method("apply_speed_boost"):
 				main.player.apply_speed_boost()
+		_apply_time_bonus("coin_time_bonus", "Coin bonus")
 		coin.queue_free()
 		coins.erase(coin)
 	main.exit_active = main.collected_coins >= main.total_coins
@@ -107,8 +108,27 @@ func handle_key_collected(door_id: int) -> void:
 	if main.collected_keys_count < main.total_keys:
 		main.collected_keys_count += 1
 	main.collected_keys_count = min(main.collected_keys_count, main.total_keys)
+	_apply_time_bonus("key_time_bonus", "Key bonus")
 	ui_controller.mark_key_collected(door_id)
 	ui_controller.update_key_status_display(main.collected_keys_count)
+
+func _apply_time_bonus(property_name: String, label: String) -> void:
+	if main == null:
+		return
+	var current_time = main.get("game_time")
+	if current_time == null:
+		return
+	var bonus_value = main.get(property_name)
+	if bonus_value == null:
+		return
+	var bonus: float = maxf(float(bonus_value), 0.0)
+	if bonus <= 0.0:
+		return
+	main.set("game_time", float(current_time) + bonus)
+	if ui_controller:
+		ui_controller.update_timer_display(float(main.get("game_time")))
+		if ui_controller.has_method("show_bonus_message"):
+			ui_controller.show_bonus_message("%s +%.1fs" % [label, bonus])
 
 func handle_door_opened(door_id: int, door_color: Color) -> void:
 	if ui_controller:

--- a/scripts/main/UIController.gd
+++ b/scripts/main/UIController.gd
@@ -18,6 +18,12 @@ var door_container: Control = null
 var door_status_container: Control = null
 var _key_ui_manager
 var path_indicator_label: Label = null
+var pause_overlay: Control = null
+var resume_button: Button = null
+var pause_menu_button: Button = null
+var pause_quit_button: Button = null
+var bonus_label: Label = null
+var bonus_tween: Tween = null
 
 var key_checkbox_nodes: Array[Button]:
 	get:
@@ -37,7 +43,12 @@ func setup(
 	door_container_ref: Control,
 	door_status_container_ref: Control,
 	speed_label_ref: Label = null,
-	path_indicator_ref: Label = null
+	path_indicator_ref: Label = null,
+	pause_overlay_ref: Control = null,
+	resume_button_ref: Button = null,
+	pause_menu_button_ref: Button = null,
+	pause_quit_button_ref: Button = null,
+	bonus_label_ref: Label = null
 ) -> void:
 	main = main_ref
 	timer_label = timer_label_ref
@@ -53,6 +64,11 @@ func setup(
 	door_status_container = door_status_container_ref
 	speed_label = speed_label_ref
 	path_indicator_label = path_indicator_ref
+	pause_overlay = pause_overlay_ref
+	resume_button = resume_button_ref
+	pause_menu_button = pause_menu_button_ref
+	pause_quit_button = pause_quit_button_ref
+	bonus_label = bonus_label_ref
 	if _key_ui_manager == null:
 		_key_ui_manager = KEY_UI_MANAGER.new()
 	_key_ui_manager.setup_containers(key_container, key_status_container, door_container, door_status_container)
@@ -161,3 +177,28 @@ func update_path_indicator(is_multi_path: bool) -> void:
 func hide_path_indicator() -> void:
 	if path_indicator_label:
 		path_indicator_label.visible = false
+
+func show_pause_menu() -> void:
+	if pause_overlay:
+		pause_overlay.visible = true
+	if resume_button:
+		resume_button.grab_focus()
+
+func hide_pause_menu() -> void:
+	if pause_overlay:
+		pause_overlay.visible = false
+
+func show_bonus_message(message: String) -> void:
+	if bonus_label == null:
+		return
+	if bonus_tween and bonus_tween.is_valid():
+		bonus_tween.kill()
+	bonus_label.text = message
+	bonus_label.visible = true
+	bonus_label.modulate = Color(1.0, 0.92, 0.25, 1.0)
+	bonus_tween = bonus_label.create_tween()
+	if bonus_tween == null:
+		return
+	bonus_tween.tween_interval(0.7)
+	bonus_tween.tween_property(bonus_label, "modulate:a", 0.0, 0.6)
+	bonus_tween.tween_callback(Callable(bonus_label, "hide"))


### PR DESCRIPTION
### Motivation
- Provide a proper pause flow during runs and reward coin/key pickups with small time bonuses to encourage exploration and support locked-route strategies.
- Expose configurable gameplay tuning for boost/ghost effects and time bonuses via the gameplay config so designers can iterate without code changes.

### Description
- Add a pause overlay and controls to the HUD (`UI/PauseOverlay`, `ResumeButton`, `PauseMenuButton`, `PauseQuitButton`) and a floating bonus label (`UI/BonusLabel`) in `scenes/Main.tscn` and `scenes/MainMenu.tscn` UI layout tweaks.
- Implement pause/resume handling and config loading in `scripts/Main.gd` with `is_paused`, `_toggle_pause_menu`, `_pause_game`, `_resume_game`, and `_load_gameplay_config`, and wire pause button signals to the new handlers.
- Apply time bonuses on coin and key collection in `scripts/main/LevelController.gd` by adding `_apply_time_bonus` and invoking it from `handle_coin_collected` and `handle_key_collected`.
- Add UI helper methods in `scripts/main/UIController.gd` to show/hide the pause menu and display timed bonus messages via `show_bonus_message` and `hide_pause_menu`.
- Add default bonus values to `config/game.cfg` (`coin_time_bonus=1.5`, `key_time_bonus=2.0`) and lower the default `speed_boost_multiplier` to `1.2`.
- Update `README.md` to document the new pause flow, the `Challenge Run` naming, time bonus behavior, config keys, and level/UI changes.

### Testing
- Ran `tests/unit/test_level_generation_scripts.gd` which verifies generation/door/key placement and spacing; the test passed.
- Ran `tests/unit/test_main_systems.gd` which verifies main HUD and systems integration including key/door indicators; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0cd206008323b162b4c36f00a64a)